### PR TITLE
Add comprehensive type annotations to 04-extract-enum-members

### DIFF
--- a/04-extract-enum-members/tests/test_extract_enum_members.py
+++ b/04-extract-enum-members/tests/test_extract_enum_members.py
@@ -16,7 +16,7 @@ from extract_enum_members import EnumMemberExtractor, create_xml_output, extract
 class TestEnumMemberExtractor(unittest.TestCase):
     """Test the EnumMemberExtractor HTML parser."""
 
-    def test_basic_enum_member_extraction(self):
+    def test_basic_enum_member_extraction(self) -> None:
         """Test extracting basic enum members."""
         html = """
         <html>
@@ -53,7 +53,7 @@ class TestEnumMemberExtractor(unittest.TestCase):
         self.assertEqual(parser.enum_members[1]["Name"], "swTangencyNone")
         self.assertEqual(parser.enum_members[1]["Description"], "0")
 
-    def test_enum_members_with_links(self):
+    def test_enum_members_with_links(self) -> None:
         """Test that links in member descriptions are converted to XMLDoc format."""
         html = """
         <html>
@@ -82,7 +82,7 @@ class TestEnumMemberExtractor(unittest.TestCase):
         self.assertIn('<see cref="SolidWorks.Interop.swconst.swOtherType_e">', parser.enum_members[0]["Description"])
         self.assertIn("swOtherType_e</see>", parser.enum_members[0]["Description"])
 
-    def test_empty_enum(self):
+    def test_empty_enum(self) -> None:
         """Test enum with no members."""
         html = """
         <html>
@@ -105,24 +105,24 @@ class TestEnumMemberExtractor(unittest.TestCase):
 class TestFileFiltering(unittest.TestCase):
     """Test filtering enum files from other files."""
 
-    def test_is_enum_file_valid(self):
+    def test_is_enum_file_valid(self) -> None:
         """Test identifying valid enum files."""
         valid_file = Path("SolidWorks.Interop.swconst~SolidWorks.Interop.swconst.swTangencyType_e_84c83747.html")
         self.assertTrue(is_enum_file(valid_file))
 
-    def test_is_enum_file_not_enum(self):
+    def test_is_enum_file_not_enum(self) -> None:
         """Test rejecting non-enum type files."""
         non_enum_file = Path("SolidWorks.Interop.sldworks~SolidWorks.Interop.sldworks.IFeature_84c83747.html")
         self.assertFalse(is_enum_file(non_enum_file))
 
-    def test_is_enum_file_members(self):
+    def test_is_enum_file_members(self) -> None:
         """Test rejecting members files."""
         members_file = Path(
             "SolidWorks.Interop.swconst~SolidWorks.Interop.swconst.swTangencyType_e_members_84c83747.html"
         )
         self.assertFalse(is_enum_file(members_file))
 
-    def test_is_enum_file_namespace(self):
+    def test_is_enum_file_namespace(self) -> None:
         """Test rejecting namespace files."""
         namespace_file = Path("SolidWorks.Interop.swconst~SolidWorks.Interop.swconst_namespace_84c83747.html")
         self.assertFalse(is_enum_file(namespace_file))
@@ -131,7 +131,7 @@ class TestFileFiltering(unittest.TestCase):
 class TestFilenameExtraction(unittest.TestCase):
     """Test extracting metadata from filenames."""
 
-    def test_extract_namespace_from_filename(self):
+    def test_extract_namespace_from_filename(self) -> None:
         """Test extracting assembly, namespace, and type name from filename."""
         test_file = Path("SolidWorks.Interop.swconst~SolidWorks.Interop.swconst.swTangencyType_e_84c83747.html")
 
@@ -145,7 +145,7 @@ class TestFilenameExtraction(unittest.TestCase):
 class TestXMLOutput(unittest.TestCase):
     """Test XML output generation."""
 
-    def test_xml_output_with_members(self):
+    def test_xml_output_with_members(self) -> None:
         """Test creating XML output with enum members."""
         enums = [
             {

--- a/shared/xmldoc_links.py
+++ b/shared/xmldoc_links.py
@@ -28,7 +28,7 @@ def convert_links_to_see_refs(html: str) -> str:
     # Or: <a href="Assembly~Namespace.Type.html">LinkText</a>
     pattern = r'<a\s+[^>]*?href="([^"]+?\.html?)"[^>]*?>([^<]+?)</a>'
 
-    def replace_link(match):
+    def replace_link(match: re.Match[str]) -> str:
         href = match.group(1)
         link_text = match.group(2)  # Don't strip - preserve spacing
 


### PR DESCRIPTION
- Add type hints to EnumMemberExtractor class methods and attributes
- Add return type annotations to all test methods
- Add type annotations to module-level functions
- Fix nested function type annotations (replace_link, replace_with_cdata)
- Add typing.Any import for complex dictionary types
- Move re import to module level for consistency
- Type check passes with mypy
- Code passes ruff linting and formatting