### PR TITLE
Add comprehensive type annotations to 02-extract-members

### DIFF
--- a/02-extract-members/extract_members.py
+++ b/02-extract-members/extract_members.py
@@ -12,27 +12,28 @@ import xml.dom.minidom as minidom
 import xml.etree.ElementTree as ET
 from html.parser import HTMLParser
 from pathlib import Path
+from typing import Any
 
 
 class MemberExtractor(HTMLParser):
     """HTML parser to extract members from SolidWorks API documentation."""
 
-    def __init__(self, url_prefix=""):
+    def __init__(self, url_prefix: str = "") -> None:
         super().__init__()
-        self.type_name = None
-        self.properties = []
-        self.methods = []
-        self.current_section = None
-        self.in_title = False
-        self.in_link = False
-        self.current_link_href = None
-        self.current_link_text = ""
-        self.in_members_table = False
-        self.in_member_link_cell = False
-        self.in_member_link = False
-        self.url_prefix = url_prefix  # Prefix to add to all URLs
+        self.type_name: str | None = None
+        self.properties: list[dict[str, str]] = []
+        self.methods: list[dict[str, str]] = []
+        self.current_section: str | None = None
+        self.in_title: bool = False
+        self.in_link: bool = False
+        self.current_link_href: str | None = None
+        self.current_link_text: str = ""
+        self.in_members_table: bool = False
+        self.in_member_link_cell: bool = False
+        self.in_member_link: bool = False
+        self.url_prefix: str = url_prefix  # Prefix to add to all URLs
 
-    def handle_starttag(self, tag, attrs):
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
         attrs_dict = dict(attrs)
 
         # Detect page title to extract type name
@@ -60,7 +61,7 @@ class MemberExtractor(HTMLParser):
                 self.current_link_href = href
                 self.current_link_text = ""
 
-    def handle_endtag(self, tag):
+    def handle_endtag(self, tag: str) -> None:
         if tag == "span" and self.in_title:
             self.in_title = False
 
@@ -87,7 +88,7 @@ class MemberExtractor(HTMLParser):
             self.current_link_href = None
             self.current_link_text = ""
 
-    def handle_data(self, data):
+    def handle_data(self, data: str) -> None:
         text = data.strip()
 
         if self.in_title and text:
@@ -108,7 +109,7 @@ class MemberExtractor(HTMLParser):
             self.current_link_text += data
 
 
-def extract_namespace_from_filename(html_file: Path) -> tuple:
+def extract_namespace_from_filename(html_file: Path) -> tuple[str | None, str | None, str | None]:
     """
     Extract namespace and assembly from the file path.
 
@@ -148,7 +149,7 @@ def extract_namespace_from_filename(html_file: Path) -> tuple:
     return None, None, None
 
 
-def extract_members_from_file(html_file: Path) -> dict:
+def extract_members_from_file(html_file: Path) -> dict[str, Any] | None:
     """Extract members from a single HTML file."""
     # Get URL prefix from parent directory
     # e.g., /sldworksapi/ for files in .../html/sldworksapi/...
@@ -183,7 +184,7 @@ def extract_members_from_file(html_file: Path) -> dict:
     }
 
 
-def create_xml_output(types: list[dict]) -> str:
+def create_xml_output(types: list[dict[str, Any]]) -> str:
     """Create XML output from extracted type information."""
     root = ET.Element("Types")
 
@@ -230,7 +231,7 @@ def create_xml_output(types: list[dict]) -> str:
     return dom.toprettyxml(indent="    ")
 
 
-def main():
+def main() -> int:
     parser = argparse.ArgumentParser(description="Extract API members from crawled HTML files")
     parser.add_argument(
         "--input-dir",

--- a/02-extract-members/tests/test_extract_members.py
+++ b/02-extract-members/tests/test_extract_members.py
@@ -14,7 +14,7 @@ from extract_members import create_xml_output, extract_members_from_file
 class TestMemberExtractor:
     """Test the HTML parser."""
 
-    def test_parse_sample_html(self, tmp_path):
+    def test_parse_sample_html(self, tmp_path: Path) -> None:
         """Test parsing a sample member HTML file."""
         # Create a sample HTML file
         sample_html = """
@@ -73,7 +73,7 @@ class TestMemberExtractor:
         assert result["PublicMethods"][0]["Name"] == "Method1"
         assert result["PublicMethods"][0]["Url"] == "/testapi/test~Method1.html"
 
-    def test_ignore_description_links(self, tmp_path):
+    def test_ignore_description_links(self, tmp_path: Path) -> None:
         """Test that links in description cells are ignored."""
         sample_html = """
         <html>
@@ -98,6 +98,7 @@ class TestMemberExtractor:
         result = extract_members_from_file(test_file)
 
         # Should only have one property, not include the link from description
+        assert result is not None
         assert len(result["PublicProperties"]) == 1
         assert result["PublicProperties"][0]["Name"] == "Property1"
 
@@ -105,7 +106,7 @@ class TestMemberExtractor:
 class TestXMLGeneration:
     """Test XML output generation."""
 
-    def test_create_xml_output(self):
+    def test_create_xml_output(self) -> None:
         """Test creating XML from type information."""
         # Example filename: SolidWorks.Interop~SolidWorks.Interop.subnamespace.ITestType_members_...
         # Assembly is before ~, Namespace is derived from full type name
@@ -133,23 +134,35 @@ class TestXMLGeneration:
         assert len(root.findall("Type")) == 1
 
         type_elem = root.find("Type")
-        assert type_elem.find("Name").text == "ITestType"
-        assert type_elem.find("Assembly").text == "SolidWorks.Interop"
-        assert type_elem.find("Namespace").text == "SolidWorks.Interop.subnamespace"
+        assert type_elem is not None
+        name_elem = type_elem.find("Name")
+        assert name_elem is not None and name_elem.text == "ITestType"
+        assembly_elem = type_elem.find("Assembly")
+        assert assembly_elem is not None and assembly_elem.text == "SolidWorks.Interop"
+        namespace_elem = type_elem.find("Namespace")
+        assert namespace_elem is not None and namespace_elem.text == "SolidWorks.Interop.subnamespace"
 
         # Check properties
         props = type_elem.find("PublicProperties")
-        assert len(props.findall("Property")) == 2
-        assert props.findall("Property")[0].find("Name").text == "Prop1"
-        assert props.findall("Property")[0].find("Url").text == "/sldworksapi/url1.html"
+        assert props is not None
+        prop_list = props.findall("Property")
+        assert len(prop_list) == 2
+        prop1_name = prop_list[0].find("Name")
+        assert prop1_name is not None and prop1_name.text == "Prop1"
+        prop1_url = prop_list[0].find("Url")
+        assert prop1_url is not None and prop1_url.text == "/sldworksapi/url1.html"
 
         # Check methods
         methods = type_elem.find("PublicMethods")
-        assert len(methods.findall("Method")) == 1
-        assert methods.findall("Method")[0].find("Name").text == "Method1"
-        assert methods.findall("Method")[0].find("Url").text == "/sldworksapi/url3.html"
+        assert methods is not None
+        method_list = methods.findall("Method")
+        assert len(method_list) == 1
+        method1_name = method_list[0].find("Name")
+        assert method1_name is not None and method1_name.text == "Method1"
+        method1_url = method_list[0].find("Url")
+        assert method1_url is not None and method1_url.text == "/sldworksapi/url3.html"
 
-    def test_xml_no_members(self):
+    def test_xml_no_members(self) -> None:
         """Test XML generation for types with no members."""
         types = [
             {
@@ -165,9 +178,13 @@ class TestXMLGeneration:
         root = ET.fromstring(xml_str)
 
         type_elem = root.find("Type")
-        assert type_elem.find("Name").text == "IEmptyType"
-        assert type_elem.find("Assembly").text == "SolidWorks.Interop.empty"
-        assert type_elem.find("Namespace").text == "SolidWorks.Interop.empty"
+        assert type_elem is not None
+        name_elem = type_elem.find("Name")
+        assert name_elem is not None and name_elem.text == "IEmptyType"
+        assembly_elem = type_elem.find("Assembly")
+        assert assembly_elem is not None and assembly_elem.text == "SolidWorks.Interop.empty"
+        namespace_elem = type_elem.find("Namespace")
+        assert namespace_elem is not None and namespace_elem.text == "SolidWorks.Interop.empty"
         # Should not have Properties or Methods elements
         assert type_elem.find("PublicProperties") is None
         assert type_elem.find("PublicMethods") is None

--- a/02-extract-members/validate_extraction.py
+++ b/02-extract-members/validate_extraction.py
@@ -11,9 +11,10 @@ import json
 import xml.etree.ElementTree as ET
 from collections import Counter
 from pathlib import Path
+from typing import Any
 
 
-def load_xml(xml_file: Path) -> ET.Element:
+def load_xml(xml_file: Path) -> ET.Element | None:
     """Load and parse the XML file."""
     try:
         tree = ET.parse(xml_file)
@@ -23,9 +24,9 @@ def load_xml(xml_file: Path) -> ET.Element:
         return None
 
 
-def validate_structure(root: ET.Element) -> dict:
+def validate_structure(root: ET.Element) -> dict[str, Any]:
     """Validate the basic XML structure."""
-    results = {"valid": True, "errors": [], "warnings": []}
+    results: dict[str, Any] = {"valid": True, "errors": [], "warnings": []}
 
     if root.tag != "Types":
         results["valid"] = False
@@ -49,9 +50,9 @@ def validate_structure(root: ET.Element) -> dict:
     return results
 
 
-def analyze_types(root: ET.Element) -> dict:
+def analyze_types(root: ET.Element) -> dict[str, Any]:
     """Analyze the extracted types."""
-    stats = {
+    stats: dict[str, Any] = {
         "total_types": 0,
         "types_with_properties": 0,
         "types_with_methods": 0,
@@ -74,11 +75,11 @@ def analyze_types(root: ET.Element) -> dict:
         has_props = props is not None and len(props.findall("Property")) > 0
         has_methods = methods is not None and len(methods.findall("Method")) > 0
 
-        if has_props:
+        if has_props and props is not None:
             stats["types_with_properties"] += 1
             stats["total_properties"] += len(props.findall("Property"))
 
-        if has_methods:
+        if has_methods and methods is not None:
             stats["types_with_methods"] += 1
             stats["total_methods"] += len(methods.findall("Method"))
 
@@ -88,9 +89,9 @@ def analyze_types(root: ET.Element) -> dict:
     return stats
 
 
-def check_duplicates(root: ET.Element) -> dict:
+def check_duplicates(root: ET.Element) -> dict[str, Any]:
     """Check for duplicate type names."""
-    type_names = []
+    type_names: list[str] = []
     for type_elem in root.findall("Type"):
         name_elem = type_elem.find("Name")
         if name_elem is not None and name_elem.text:
@@ -102,10 +103,10 @@ def check_duplicates(root: ET.Element) -> dict:
     return {"has_duplicates": len(duplicates) > 0, "duplicates": duplicates, "unique_types": len(counter)}
 
 
-def check_url_format(root: ET.Element) -> dict:
+def check_url_format(root: ET.Element) -> dict[str, Any]:
     """Check that URLs follow expected format."""
-    issues = []
-    total_urls = 0
+    issues: list[str] = []
+    total_urls: int = 0
 
     for type_elem in root.findall("Type"):
         type_name = type_elem.find("Name")
@@ -134,7 +135,7 @@ def check_url_format(root: ET.Element) -> dict:
     return {"total_urls": total_urls, "issues": issues, "all_valid": len(issues) == 0}
 
 
-def main():
+def main() -> int:
     parser = argparse.ArgumentParser(description="Validate extracted API members XML")
     parser.add_argument(
         "--xml-file",


### PR DESCRIPTION
- Add type hints to all functions in extract_members.py
  - MemberExtractor class methods with proper parameter and return types
  - Function signatures with specific return types (dict[str, Any] | None, tuple[str | None, ...])

- Add type hints to all test methods in test_extract_members.py
  - Test methods with Path and None return types
  - Add None checks for mypy compliance

- Improve type hints in validate_extraction.py
  - All validation functions return dict[str, Any]
  - load_xml returns ET.Element | None
  - Add explicit type annotations for local variables

All code passes mypy strict type checking and ruff linting.