### PR TITLE
Add comprehensive Python type annotations to 01-crawl-toc-pages

### DIFF
--- a/01-crawl-toc-pages/solidworks_scraper/middlewares.py
+++ b/01-crawl-toc-pages/solidworks_scraper/middlewares.py
@@ -3,8 +3,13 @@
 # See documentation in:
 # https://docs.scrapy.org/en/latest/topics/spider-middleware.html
 
-# useful for handling different item types with a single interface
+from collections.abc import AsyncIterator, Iterable
+from typing import Any
+
 from scrapy import signals
+from scrapy.crawler import Crawler
+from scrapy.http import Request, Response
+from scrapy.spiders import Spider
 
 
 class SolidworksScraperSpiderMiddleware:
@@ -13,40 +18,44 @@ class SolidworksScraperSpiderMiddleware:
     # passed objects.
 
     @classmethod
-    def from_crawler(cls, crawler):
+    def from_crawler(cls, crawler: Crawler) -> "SolidworksScraperSpiderMiddleware":
         # This method is used by Scrapy to create your spiders.
         s = cls()
         crawler.signals.connect(s.spider_opened, signal=signals.spider_opened)
         return s
 
-    def process_spider_input(self, response, spider):
+    def process_spider_input(self, response: Response, spider: Spider) -> None:
         # Called for each response that goes through the spider
         # middleware and into the spider.
 
         # Should return None or raise an exception.
         return None
 
-    def process_spider_output(self, response, result, spider):
+    def process_spider_output(
+        self, response: Response, result: Iterable[Any], spider: Spider
+    ) -> Iterable[Request | dict[str, Any]]:
         # Called with the results returned from the Spider, after
         # it has processed the response.
 
         # Must return an iterable of Request, or item objects.
         yield from result
 
-    def process_spider_exception(self, response, exception, spider):
+    def process_spider_exception(
+        self, response: Response, exception: Exception, spider: Spider
+    ) -> None | Iterable[Request | dict[str, Any]]:
         # Called when a spider or process_spider_input() method
         # (from other spider middleware) raises an exception.
 
         # Should return either None or an iterable of Request or item objects.
         pass
 
-    async def process_start(self, start):
+    async def process_start(self, start: AsyncIterator[Any]) -> AsyncIterator[Request | dict[str, Any]]:
         # Called with an async iterator over the spider start() method or the
         # maching method of an earlier spider middleware.
         async for item_or_request in start:
             yield item_or_request
 
-    def spider_opened(self, spider):
+    def spider_opened(self, spider: Spider) -> None:
         spider.logger.info(f"Spider opened: {spider.name}")
 
 
@@ -56,13 +65,13 @@ class SolidworksScraperDownloaderMiddleware:
     # passed objects.
 
     @classmethod
-    def from_crawler(cls, crawler):
+    def from_crawler(cls, crawler: Crawler) -> "SolidworksScraperDownloaderMiddleware":
         # This method is used by Scrapy to create your spiders.
         s = cls()
         crawler.signals.connect(s.spider_opened, signal=signals.spider_opened)
         return s
 
-    def process_request(self, request, spider):
+    def process_request(self, request: Request, spider: Spider) -> None | Response | Request:
         # Called for each request that goes through the downloader
         # middleware.
 
@@ -74,7 +83,7 @@ class SolidworksScraperDownloaderMiddleware:
         #   installed downloader middleware will be called
         return None
 
-    def process_response(self, request, response, spider):
+    def process_response(self, request: Request, response: Response, spider: Spider) -> Response | Request:
         # Called with the response returned from the downloader.
 
         # Must either;
@@ -83,7 +92,9 @@ class SolidworksScraperDownloaderMiddleware:
         # - or raise IgnoreRequest
         return response
 
-    def process_exception(self, request, exception, spider):
+    def process_exception(
+        self, request: Request, exception: Exception, spider: Spider
+    ) -> None | Response | Request:
         # Called when a download handler or a process_request()
         # (from other downloader middleware) raises an exception.
 
@@ -93,5 +104,5 @@ class SolidworksScraperDownloaderMiddleware:
         # - return a Request object: stops process_exception() chain
         pass
 
-    def spider_opened(self, spider):
+    def spider_opened(self, spider: Spider) -> None:
         spider.logger.info(f"Spider opened: {spider.name}")

--- a/01-crawl-toc-pages/solidworks_scraper/settings.py
+++ b/01-crawl-toc-pages/solidworks_scraper/settings.py
@@ -14,7 +14,7 @@ BOT_NAME = "solidworks_scraper"
 SPIDER_MODULES = ["solidworks_scraper.spiders"]
 NEWSPIDER_MODULE = "solidworks_scraper.spiders"
 
-ADDONS = {}
+ADDONS: dict[str, str] = {}
 
 
 # Crawl responsibly by identifying yourself (and your website) on the user-agent

--- a/01-crawl-toc-pages/solidworks_scraper/spiders/api_docs_spider.py
+++ b/01-crawl-toc-pages/solidworks_scraper/spiders/api_docs_spider.py
@@ -225,12 +225,13 @@ class ApiDocsSpider(scrapy.Spider):
     def handle_error(self, failure: Failure) -> Generator[dict[str, Any], None, None]:
         """Handle failed requests"""
         self.stats["failed_pages"] += 1
-        self.logger.error(f"Failed to crawl {failure.request.url}: {failure.value}")
+        request_url = failure.request.url  # type: ignore[attr-defined]
+        self.logger.error(f"Failed to crawl {request_url}: {failure.value}")
 
         # Create error item for logging
         error_item: dict[str, Any] = {
             "type": "error",
-            "url": failure.request.url,
+            "url": request_url,
             "error": str(failure.value),
             "timestamp": datetime.now().isoformat(),
             "session_id": self.session_id,

--- a/01-crawl-toc-pages/tests/test_pipelines.py
+++ b/01-crawl-toc-pages/tests/test_pipelines.py
@@ -26,7 +26,7 @@ from solidworks_scraper.pipelines import (
 class TestHtmlSavePipeline:
     """Test suite for HtmlSavePipeline"""
 
-    def setup_method(self):
+    def setup_method(self) -> None:
         """Set up test fixtures"""
         # Create temporary directory for testing
         self.temp_dir = tempfile.mkdtemp()
@@ -36,11 +36,11 @@ class TestHtmlSavePipeline:
         self.pipeline.output_dir = Path(self.temp_dir) / "html"
         self.pipeline.output_dir.mkdir(parents=True, exist_ok=True)
 
-    def teardown_method(self):
+    def teardown_method(self) -> None:
         """Clean up after tests"""
         shutil.rmtree(self.temp_dir, ignore_errors=True)
 
-    def test_url_to_file_path_conversion(self):
+    def test_url_to_file_path_conversion(self) -> None:
         """Test URL to file path conversion"""
         # Test simple URL
         url1 = "https://help.solidworks.com/2026/english/api/sldworksapi/test.html"
@@ -59,7 +59,7 @@ class TestHtmlSavePipeline:
         path3 = self.pipeline.url_to_file_path(url3)
         assert path3.suffix == ".html"
 
-    def test_url_to_file_path_deterministic(self):
+    def test_url_to_file_path_deterministic(self) -> None:
         """Test that URL to file path conversion is deterministic"""
         url = "https://help.solidworks.com/2026/english/api/test.html?id=123&format=p"
 
@@ -75,7 +75,7 @@ class TestHtmlSavePipeline:
         assert "test_" in path1.name
         # The hash should be the same across test runs
 
-    def test_process_item_saves_html(self):
+    def test_process_item_saves_html(self) -> None:
         """Test that HTML content is saved correctly"""
         # Create mock spider
         mock_spider = Mock()
@@ -102,7 +102,7 @@ class TestHtmlSavePipeline:
         # Check file path was added to item
         assert "file_path" in processed_item
 
-    def test_process_item_skips_error_items(self):
+    def test_process_item_skips_error_items(self) -> None:
         """Test that error items are skipped"""
         mock_spider = Mock()
         error_item = {"type": "error", "url": "test.html", "error": "Failed"}
@@ -110,7 +110,7 @@ class TestHtmlSavePipeline:
         result = self.pipeline.process_item(error_item, mock_spider)
         assert result == error_item  # Should return unchanged
 
-    def test_process_item_handles_missing_content(self):
+    def test_process_item_handles_missing_content(self) -> None:
         """Test handling of items without content"""
         mock_spider = Mock()
         mock_spider.logger = Mock()
@@ -125,7 +125,7 @@ class TestHtmlSavePipeline:
 class TestMetadataLogPipeline:
     """Test suite for MetadataLogPipeline"""
 
-    def setup_method(self):
+    def setup_method(self) -> None:
         """Set up test fixtures"""
         self.temp_dir = tempfile.mkdtemp()
 
@@ -137,11 +137,11 @@ class TestMetadataLogPipeline:
         self.pipeline.errors_file = self.pipeline.metadata_dir / "errors.jsonl"
         self.pipeline.manifest_file = self.pipeline.metadata_dir / "manifest.json"
 
-    def teardown_method(self):
+    def teardown_method(self) -> None:
         """Clean up after tests"""
         shutil.rmtree(self.temp_dir, ignore_errors=True)
 
-    def test_manifest_creation(self):
+    def test_manifest_creation(self) -> None:
         """Test that manifest file is created"""
         self.pipeline.init_manifest()
         assert self.pipeline.manifest_file.exists()
@@ -153,7 +153,7 @@ class TestMetadataLogPipeline:
         assert manifest["boundary"] == "/2026/english/api/"
         assert manifest["crawl_delay_seconds"] == 2
 
-    def test_process_item_logs_metadata(self):
+    def test_process_item_logs_metadata(self) -> None:
         """Test that metadata is logged correctly"""
         mock_spider = Mock()
         mock_spider.logger = Mock()
@@ -185,7 +185,7 @@ class TestMetadataLogPipeline:
         assert saved_metadata["content_hash"] == "abc123"
         assert saved_metadata["title"] == "Test Page"
 
-    def test_log_error(self):
+    def test_log_error(self) -> None:
         """Test error logging"""
         error_item = {
             "type": "error",
@@ -213,7 +213,7 @@ class TestMetadataLogPipeline:
 class TestDuplicateCheckPipeline:
     """Test suite for DuplicateCheckPipeline"""
 
-    def setup_method(self):
+    def setup_method(self) -> None:
         """Set up test fixtures"""
         self.temp_dir = tempfile.mkdtemp()
 
@@ -234,11 +234,11 @@ class TestDuplicateCheckPipeline:
             self.pipeline = DuplicateCheckPipeline()
             self.pipeline.seen_urls = {"https://test.com/existing1.html", "https://test.com/existing2.html"}
 
-    def teardown_method(self):
+    def teardown_method(self) -> None:
         """Clean up after tests"""
         shutil.rmtree(self.temp_dir, ignore_errors=True)
 
-    def test_duplicate_detection(self):
+    def test_duplicate_detection(self) -> None:
         """Test that duplicates are detected"""
         mock_spider = Mock()
         mock_spider.logger = Mock()
@@ -251,7 +251,7 @@ class TestDuplicateCheckPipeline:
 
         assert "Duplicate URL" in str(exc_info.value)
 
-    def test_new_url_processing(self):
+    def test_new_url_processing(self) -> None:
         """Test that new URLs are processed"""
         mock_spider = Mock()
 
@@ -266,11 +266,11 @@ class TestDuplicateCheckPipeline:
 class TestValidationPipeline:
     """Test suite for ValidationPipeline"""
 
-    def setup_method(self):
+    def setup_method(self) -> None:
         """Set up test fixtures"""
         self.pipeline = ValidationPipeline()
 
-    def test_validate_complete_item(self):
+    def test_validate_complete_item(self) -> None:
         """Test validation of complete item"""
         mock_spider = Mock()
         mock_spider.logger = Mock()
@@ -287,7 +287,7 @@ class TestValidationPipeline:
         # No warnings should be logged for valid item
         mock_spider.logger.warning.assert_not_called()
 
-    def test_validate_missing_fields(self):
+    def test_validate_missing_fields(self) -> None:
         """Test validation catches missing fields"""
         mock_spider = Mock()
         mock_spider.logger = Mock()
@@ -301,7 +301,7 @@ class TestValidationPipeline:
         # Should log warnings for missing fields
         assert mock_spider.logger.warning.call_count >= 3
 
-    def test_validate_short_content(self):
+    def test_validate_short_content(self) -> None:
         """Test validation warns about short content"""
         mock_spider = Mock()
         mock_spider.logger = Mock()
@@ -318,7 +318,7 @@ class TestValidationPipeline:
         mock_spider.logger.warning.assert_called()
         assert "short content" in mock_spider.logger.warning.call_args[0][0].lower()
 
-    def test_validate_non_html_content(self):
+    def test_validate_non_html_content(self) -> None:
         """Test validation detects non-HTML content"""
         mock_spider = Mock()
         mock_spider.logger = Mock()
@@ -336,7 +336,7 @@ class TestValidationPipeline:
         assert "doesn't appear to be HTML" in mock_spider.logger.warning.call_args[0][0]
 
 
-def test_regression_crawl_count():
+def test_regression_crawl_count() -> None:
     """
     Regression test to ensure crawler maintains minimum page count.
     This is a placeholder that would run after an actual crawl.

--- a/01-crawl-toc-pages/tests/test_spider.py
+++ b/01-crawl-toc-pages/tests/test_spider.py
@@ -18,19 +18,19 @@ from solidworks_scraper.spiders.api_docs_spider import ApiDocsSpider
 class TestApiDocsSpider:
     """Test suite for ApiDocsSpider"""
 
-    def setup_method(self):
+    def setup_method(self) -> None:
         """Set up test fixtures"""
         self.spider = ApiDocsSpider()
 
-    def test_spider_name(self):
+    def test_spider_name(self) -> None:
         """Test spider has correct name"""
         assert self.spider.name == "api_docs"
 
-    def test_allowed_domains(self):
+    def test_allowed_domains(self) -> None:
         """Test spider has correct allowed domains"""
         assert "help.solidworks.com" in self.spider.allowed_domains
 
-    def test_url_boundary_checking(self):
+    def test_url_boundary_checking(self) -> None:
         """Test that spider respects URL boundaries"""
         # Test that spider only processes URLs within the boundary
         from urllib.parse import urlparse
@@ -46,7 +46,7 @@ class TestApiDocsSpider:
         assert not urlparse(bad_url2).path.startswith(self.spider.base_path)
         assert not urlparse(bad_url3).path.startswith(self.spider.base_path)
 
-    def test_parse_page_with_valid_html(self):
+    def test_parse_page_with_valid_html(self) -> None:
         """Test parsing a valid HTML page"""
         # Create mock response with __NEXT_DATA__ JSON
         help_text_content = """
@@ -68,7 +68,7 @@ class TestApiDocsSpider:
         mock_response.body = b"<html><body>Test</body></html>"
 
         # Mock xpath to return the JSON and title
-        def xpath_side_effect(query):
+        def xpath_side_effect(query: str) -> Mock:
             result = Mock()
             if "__NEXT_DATA__" in query:
                 result.get = Mock(return_value=json.dumps(next_data_json))
@@ -95,7 +95,7 @@ class TestApiDocsSpider:
         assert "timestamp" in item
         assert "session_id" in item
 
-    def test_parse_page_skips_non_html(self):
+    def test_parse_page_skips_non_html(self) -> None:
         """Test that non-HTML content is skipped"""
         # Create mock response with non-HTML content type
         mock_response = Mock(spec=Response)
@@ -109,7 +109,7 @@ class TestApiDocsSpider:
         assert len(items) == 0
         assert self.spider.stats["skipped_pages"] == 1
 
-    def test_parse_page_skips_outside_boundary(self):
+    def test_parse_page_skips_outside_boundary(self) -> None:
         """Test that pages outside boundary are skipped"""
         # Create mock response outside boundary
         mock_response = Mock(spec=Response)
@@ -123,7 +123,7 @@ class TestApiDocsSpider:
         assert len(items) == 0
         assert self.spider.stats["skipped_pages"] == 1  # First skip in this test
 
-    def test_handle_error(self):
+    def test_handle_error(self) -> None:
         """Test error handling"""
         # Create mock failure
         mock_failure = Mock()
@@ -143,7 +143,7 @@ class TestApiDocsSpider:
         assert "timestamp" in error_item
         assert self.spider.stats["failed_pages"] == 1
 
-    def test_start_requests(self):
+    def test_start_requests(self) -> None:
         """Test that start URLs are correctly configured"""
         # Check that spider has the correct start URL for expandToc
         assert len(self.spider.start_urls) == 1
@@ -153,7 +153,7 @@ class TestApiDocsSpider:
         assert "language=english" in start_url
         assert "product=api" in start_url
 
-    def test_spider_statistics_tracking(self):
+    def test_spider_statistics_tracking(self) -> None:
         """Test that spider tracks statistics correctly"""
         # Initial state
         assert self.spider.stats["total_pages"] == 0
@@ -170,7 +170,7 @@ class TestApiDocsSpider:
         mock_response.headers = {"Content-Type": b"text/html"}
         mock_response.body = b"<html><body>Test</body></html>"
 
-        def xpath_side_effect(query):
+        def xpath_side_effect(query: str) -> Mock:
             result = Mock()
             if "__NEXT_DATA__" in query:
                 result.get = Mock(return_value=json.dumps(next_data))
@@ -190,7 +190,7 @@ class TestApiDocsSpider:
         assert self.spider.stats["total_pages"] == 1
         assert self.spider.stats["successful_pages"] == 1
 
-    def test_duplicate_url_handling(self):
+    def test_duplicate_url_handling(self) -> None:
         """Test that duplicate URLs are not processed twice"""
         # Create mock response with __NEXT_DATA__
         help_text = "<html><body>Test</body></html>"
@@ -202,7 +202,7 @@ class TestApiDocsSpider:
         mock_response.headers = {"Content-Type": b"text/html"}
         mock_response.body = b"<html><body>Test</body></html>"
 
-        def xpath_side_effect(query):
+        def xpath_side_effect(query: str) -> Mock:
             result = Mock()
             if "__NEXT_DATA__" in query:
                 result.get = Mock(return_value=json.dumps(next_data))
@@ -223,7 +223,7 @@ class TestApiDocsSpider:
         assert len(items1) == 1
         assert len(items2) == 0  # Second parse should skip
 
-    def test_extract_urls_from_json(self):
+    def test_extract_urls_from_json(self) -> None:
         """Test extracting URLs from JSON structure"""
         # Test with nested structure
         json_data = {
@@ -246,7 +246,7 @@ class TestApiDocsSpider:
         assert "/2026/english/api/page3.htm" in urls
         assert "/2026/english/api/page4.htm" in urls
 
-    def test_extract_urls_from_json_no_data(self):
+    def test_extract_urls_from_json_no_data(self) -> None:
         """Test extract_urls_from_json handles empty data gracefully"""
         # Test with empty dict
         assert self.spider.extract_urls_from_json({}) == []

--- a/01-crawl-toc-pages/validate_crawl.py
+++ b/01-crawl-toc-pages/validate_crawl.py
@@ -23,15 +23,15 @@ import jsonlines
 class CrawlValidator:
     """Validates crawl completeness and integrity"""
 
-    def __init__(self, output_dir):
-        self.output_dir = Path(output_dir)
-        self.html_dir = self.output_dir / "html"
-        self.metadata_dir = self.output_dir.parent / "metadata"
-        self.errors = []
-        self.warnings = []
-        self.stats = defaultdict(int)
+    def __init__(self, output_dir: str | Path) -> None:
+        self.output_dir: Path = Path(output_dir)
+        self.html_dir: Path = self.output_dir / "html"
+        self.metadata_dir: Path = self.output_dir.parent / "metadata"
+        self.errors: list[str] = []
+        self.warnings: list[str] = []
+        self.stats: defaultdict[str, int] = defaultdict(int)
 
-    def validate(self, verbose=False):
+    def validate(self, verbose: bool = False) -> bool:
         """Run all validation checks"""
         print("=" * 60)
         print("SOLIDWORKS API DOCUMENTATION CRAWL VALIDATOR")
@@ -75,7 +75,7 @@ class CrawlValidator:
 
         return success
 
-    def _check_directory_structure(self):
+    def _check_directory_structure(self) -> bool:
         """Check that expected directories exist"""
         print("Checking directory structure...")
 
@@ -93,7 +93,7 @@ class CrawlValidator:
         print("  [OK] Directory structure verified\n")
         return True
 
-    def _validate_metadata_files(self, verbose):
+    def _validate_metadata_files(self, verbose: bool) -> None:
         """Validate metadata files exist and are valid"""
         print("Validating metadata files...")
 
@@ -134,7 +134,7 @@ class CrawlValidator:
 
         print("  [OK] Metadata files validated\n")
 
-    def _validate_urls_crawled(self, verbose):
+    def _validate_urls_crawled(self, verbose: bool) -> bool:
         """Validate URLs crawled metadata"""
         print("Validating crawled URLs...")
 
@@ -203,7 +203,7 @@ class CrawlValidator:
             self.errors.append(f"Error validating URLs: {e}")
             return False
 
-    def _validate_html_files(self, verbose):
+    def _validate_html_files(self, verbose: bool) -> bool:
         """Validate HTML files match metadata"""
         print("Validating HTML files...")
 
@@ -250,8 +250,8 @@ class CrawlValidator:
 
             for file in sample:
                 try:
-                    with open(file, encoding="utf-8") as f:
-                        content = f.read()
+                    with open(file, encoding="utf-8") as file_handle:
+                        content = file_handle.read()
 
                     if len(content) < 100:
                         self.warnings.append(f"Suspiciously small HTML file: {file.name}")
@@ -265,7 +265,7 @@ class CrawlValidator:
         print("  [OK] HTML files validated\n")
         return True
 
-    def _check_duplicates(self, verbose):
+    def _check_duplicates(self, verbose: bool) -> None:
         """Check for duplicate content based on hashes"""
         print("Checking for duplicates...")
 
@@ -294,7 +294,7 @@ class CrawlValidator:
         print(f"  Duplicate content groups: {len(duplicates)}")
         print("  [OK] Duplicate check completed\n")
 
-    def _validate_statistics(self):
+    def _validate_statistics(self) -> bool:
         """Validate crawl statistics"""
         print("Validating crawl statistics...")
 
@@ -332,7 +332,7 @@ class CrawlValidator:
             self.errors.append(f"Error reading statistics: {e}")
             return False
 
-    def _generate_report(self):
+    def _generate_report(self) -> None:
         """Generate validation report"""
         print("Validation Report Summary")
         print("-" * 40)
@@ -379,7 +379,7 @@ class CrawlValidator:
         print(f"\nDetailed report saved to: {report_file.name}")
 
 
-def main():
+def main() -> None:
     """Main entry point"""
     parser = argparse.ArgumentParser(description="Validate SolidWorks API documentation crawl")
     parser.add_argument(


### PR DESCRIPTION
This commit adds complete type annotations to all Python files in the
01-crawl-toc-pages folder to improve code quality and enable better
static type checking with mypy.

Changes:
- Added type annotations to middlewares.py (spider and downloader middleware classes)
- Added type annotations to validate_crawl.py (CrawlValidator class and all methods)
- Added type annotations to test_pipelines.py (all test methods)
- Added type annotations to test_spider.py (all test methods and helper functions)
- Added type annotation to settings.py (ADDONS dict)
- Added type: ignore comments in api_docs_spider.py for Twisted Failure attributes

All changes have been validated with mypy and pass without errors.