### PR TITLE
Add Python type annotations to folder 03

### DIFF
--- a/03-extract-type-info/tests/test_extract_type_info.py
+++ b/03-extract-type-info/tests/test_extract_type_info.py
@@ -16,7 +16,7 @@ from extract_type_info import TypeInfoExtractor, extract_namespace_from_filename
 class TestTypeInfoExtractor(unittest.TestCase):
     """Test the TypeInfoExtractor HTML parser."""
 
-    def test_basic_type_extraction(self):
+    def test_basic_type_extraction(self) -> None:
         """Test extracting basic type information."""
         html = """
         <html>
@@ -36,7 +36,7 @@ class TestTypeInfoExtractor(unittest.TestCase):
         self.assertEqual(parser.type_name, "IAdvancedHoleFeatureData")
         self.assertIn("Advanced Hole feature data", parser.get_description())
 
-    def test_description_with_links_converted_to_see_cref(self):
+    def test_description_with_links_converted_to_see_cref(self) -> None:
         """Test that links in description are converted to XMLDoc <see cref> format (IDocumentSpecification bug)."""
         html = """
         <html>
@@ -64,7 +64,7 @@ class TestTypeInfoExtractor(unittest.TestCase):
         # Should not contain the original HTML anchor tag
         self.assertNotIn("<a href=", description)
 
-    def test_example_extraction(self):
+    def test_example_extraction(self) -> None:
         """Test extracting examples from type documentation."""
         html = """
         <html>
@@ -92,7 +92,7 @@ class TestTypeInfoExtractor(unittest.TestCase):
         self.assertEqual(parser.examples[0]["Url"], "/sldworksapi/Create_Advanced_Hole_Example_VB.htm")
         self.assertEqual(parser.examples[1]["Language"], "VB.NET")
 
-    def test_remarks_extraction(self):
+    def test_remarks_extraction(self) -> None:
         """Test extracting remarks section."""
         html = """
         <html>
@@ -115,7 +115,7 @@ class TestTypeInfoExtractor(unittest.TestCase):
         remarks = parser.get_remarks()
         self.assertIn("Advanced Hole feature", remarks)
 
-    def test_remarks_with_links_converted_to_see_cref(self):
+    def test_remarks_with_links_converted_to_see_cref(self) -> None:
         """Test that links in remarks are converted to XMLDoc <see cref> format."""
         html = """
         <html>
@@ -149,7 +149,7 @@ class TestTypeInfoExtractor(unittest.TestCase):
         # Should not contain the original HTML anchor tag
         self.assertNotIn("<a href=", remarks)
 
-    def test_language_inference_from_filename(self):
+    def test_language_inference_from_filename(self) -> None:
         """Test inferring programming language from filename."""
         parser = TypeInfoExtractor()
 
@@ -158,7 +158,7 @@ class TestTypeInfoExtractor(unittest.TestCase):
         self.assertEqual(parser._infer_language_from_filename("Example_CSharp.htm"), "C#")
         self.assertEqual(parser._infer_language_from_filename("Example_CPP.htm"), "C++")
 
-    def test_accessors_section_not_collected_as_examples(self):
+    def test_accessors_section_not_collected_as_examples(self) -> None:
         """Test that links in Accessors section are not collected as examples (ICrossBreakFeatureData bug)."""
         html = """
         <html>
@@ -209,7 +209,7 @@ class TestTypeInfoExtractor(unittest.TestCase):
         self.assertNotIn("/sldworksapi/SWObjectModel.pdf#CrossBreakFeatureData", example_urls)
         self.assertNotIn("/sldworksapi/ICrossBreakFeatureData_members.html", example_urls)
 
-    def test_cdata_wrapping_in_xml_output(self):
+    def test_cdata_wrapping_in_xml_output(self) -> None:
         """Test that descriptions and remarks are wrapped in CDATA in final XML output."""
         from extract_type_info import create_xml_output
 
@@ -238,7 +238,7 @@ class TestTypeInfoExtractor(unittest.TestCase):
         # Verify no __cdata__ attributes in final output
         self.assertNotIn('__cdata__="true"', xml_output)
 
-    def test_non_type_links_converted_to_see_href(self):
+    def test_non_type_links_converted_to_see_href(self) -> None:
         """Test that non-type links (guide pages) are converted to <see href> format (IPLMObjectSpecification bug)."""
         html = """
         <html>
@@ -267,7 +267,7 @@ class TestTypeInfoExtractor(unittest.TestCase):
         # Should not contain the original HTML anchor tag
         self.assertNotIn("<a href=", description)
 
-    def test_type_links_with_path_prefix_converted_to_see_cref(self):
+    def test_type_links_with_path_prefix_converted_to_see_cref(self) -> None:
         """Test that type reference links with path prefixes are converted to <see cref> (swZonalSectionViewZones_e bug)."""
         html = """
         <html>
@@ -296,7 +296,7 @@ class TestTypeInfoExtractor(unittest.TestCase):
         # Should NOT use href for type references
         self.assertNotIn("<see href=", remarks)
 
-    def test_remarks_only_from_h1_section(self):
+    def test_remarks_only_from_h1_section(self) -> None:
         """Test that 'Remarks' text in member descriptions doesn't trigger remarks section (swWzdHoleStandardFastenerTypes_e bug)."""
         html = """
         <html>
@@ -339,7 +339,7 @@ class TestTypeInfoExtractor(unittest.TestCase):
 class TestFilenameExtraction(unittest.TestCase):
     """Test extracting metadata from filenames."""
 
-    def test_extract_namespace_from_filename(self):
+    def test_extract_namespace_from_filename(self) -> None:
         """Test extracting assembly, namespace, and type name from filename."""
         # Create a mock Path object
         test_file = Path(
@@ -352,7 +352,7 @@ class TestFilenameExtraction(unittest.TestCase):
         self.assertEqual(namespace, "SolidWorks.Interop.sldworks")
         self.assertEqual(type_name, "IAdvancedHoleFeatureData")
 
-    def test_extract_namespace_different_assembly(self):
+    def test_extract_namespace_different_assembly(self) -> None:
         """Test with different assembly and namespace."""
         test_file = Path(
             "SolidWorks.Interop.dsgnchk~SolidWorks.Interop.dsgnchk.ISWDesignCheck_8a2a04ee_8a2a04ee.htmll.html"
@@ -368,32 +368,32 @@ class TestFilenameExtraction(unittest.TestCase):
 class TestFileFiltering(unittest.TestCase):
     """Test filtering type files from other files."""
 
-    def test_is_type_file_valid(self):
+    def test_is_type_file_valid(self) -> None:
         """Test identifying valid type files."""
         valid_file = Path(
             "SolidWorks.Interop.sldworks~SolidWorks.Interop.sldworks.IAdvancedHoleFeatureData_84c83747.html"
         )
         self.assertTrue(is_type_file(valid_file))
 
-    def test_is_type_file_members(self):
+    def test_is_type_file_members(self) -> None:
         """Test rejecting members files."""
         members_file = Path(
             "SolidWorks.Interop.sldworks~SolidWorks.Interop.sldworks.IAdvancedHoleFeatureData_members_84c83747.html"
         )
         self.assertFalse(is_type_file(members_file))
 
-    def test_is_type_file_namespace(self):
+    def test_is_type_file_namespace(self) -> None:
         """Test rejecting namespace files."""
         namespace_file = Path("SolidWorks.Interop.sldworks~SolidWorks.Interop.sldworks_namespace_84c83747.html")
         self.assertFalse(is_type_file(namespace_file))
 
-    def test_is_type_file_special(self):
+    def test_is_type_file_special(self) -> None:
         """Test rejecting special files."""
         self.assertFalse(is_type_file(Path("FunctionalCategories-sldworksapi_123.html")))
         self.assertFalse(is_type_file(Path("ReleaseNotes-sldworksapi_456.html")))
         self.assertFalse(is_type_file(Path("help_list_789.html")))
 
-    def test_is_type_file_without_tilde(self):
+    def test_is_type_file_without_tilde(self) -> None:
         """Test rejecting files without tilde separator."""
         invalid_file = Path("SomeRandomFile.html")
         self.assertFalse(is_type_file(invalid_file))

--- a/03-extract-type-info/validate_extraction.py
+++ b/03-extract-type-info/validate_extraction.py
@@ -9,16 +9,17 @@ import argparse
 import json
 import xml.etree.ElementTree as ET
 from pathlib import Path
+from typing import Any
 
 
-def validate_xml_structure(xml_file: Path) -> dict:
+def validate_xml_structure(xml_file: Path) -> dict[str, Any]:
     """
     Validate that the XML file is well-formed and has expected structure.
 
     Returns:
         Dictionary with validation results
     """
-    results = {
+    results: dict[str, Any] = {
         "valid_xml": False,
         "has_root": False,
         "type_count": 0,
@@ -78,14 +79,14 @@ def validate_xml_structure(xml_file: Path) -> dict:
     return results
 
 
-def validate_summary(summary_file: Path) -> dict:
+def validate_summary(summary_file: Path) -> dict[str, Any]:
     """
     Validate the extraction summary metadata.
 
     Returns:
         Dictionary with validation results
     """
-    results = {
+    results: dict[str, Any] = {
         "valid_json": False,
         "has_required_fields": False,
         "total_files": 0,
@@ -119,7 +120,7 @@ def validate_summary(summary_file: Path) -> dict:
     return results
 
 
-def main():
+def main() -> int:
     parser = argparse.ArgumentParser(description="Validate type information extraction results")
     parser.add_argument(
         "--metadata-dir",
@@ -157,14 +158,14 @@ def main():
     print(f"  [PASS] Root element: {'Types' if xml_results['has_root'] else 'INVALID'}")
     print(f"  [INFO] Type count: {xml_results['type_count']}")
     print(
-        f"  [INFO] Types with description: {xml_results['types_with_description']} ({100*xml_results['types_with_description']//xml_results['type_count'] if xml_results['type_count'] > 0 else 0}%)"
+        f"  [INFO] Types with description: {xml_results['types_with_description']} ({100 * xml_results['types_with_description'] // xml_results['type_count'] if xml_results['type_count'] > 0 else 0}%)"
     )
     print(
-        f"  [INFO] Types with examples: {xml_results['types_with_examples']} ({100*xml_results['types_with_examples']//xml_results['type_count'] if xml_results['type_count'] > 0 else 0}%)"
+        f"  [INFO] Types with examples: {xml_results['types_with_examples']} ({100 * xml_results['types_with_examples'] // xml_results['type_count'] if xml_results['type_count'] > 0 else 0}%)"
     )
     print(f"  [INFO] Total examples: {xml_results['total_examples']}")
     print(
-        f"  [INFO] Types with remarks: {xml_results['types_with_remarks']} ({100*xml_results['types_with_remarks']//xml_results['type_count'] if xml_results['type_count'] > 0 else 0}%)"
+        f"  [INFO] Types with remarks: {xml_results['types_with_remarks']} ({100 * xml_results['types_with_remarks'] // xml_results['type_count'] if xml_results['type_count'] > 0 else 0}%)"
     )
 
     if xml_results["issues"]:

--- a/shared/xmldoc_links.py
+++ b/shared/xmldoc_links.py
@@ -28,7 +28,7 @@ def convert_links_to_see_refs(html: str) -> str:
     # Or: <a href="Assembly~Namespace.Type.html">LinkText</a>
     pattern = r'<a\s+[^>]*?href="([^"]+?\.html?)"[^>]*?>([^<]+?)</a>'
 
-    def replace_link(match):
+    def replace_link(match: re.Match[str]) -> str:
         href = match.group(1)
         link_text = match.group(2)  # Don't strip - preserve spacing
 


### PR DESCRIPTION
- Added type annotations to TypeInfoExtractor class and all methods
- Added return type annotations to all functions in extract_type_info.py
- Added type annotations to validation functions in validate_extraction.py
- Added return type annotations to all test methods
- Added type annotation to shared xmldoc_links helper function
- Fixed type issues identified by mypy
- All files pass mypy type checking with no errors
- Code formatted with ruff