### PR TITLE
Remove SIM103 ignore rule from linter

### DIFF
--- a/03-extract-type-info/extract_type_info.py
+++ b/03-extract-type-info/extract_type_info.py
@@ -425,10 +425,7 @@ def is_type_file(html_file: Path) -> bool:
         return False
 
     # Must have the typical type file pattern: Assembly~Namespace.Type_hash_hash.html
-    if "~" in filename and ".html" in filename:
-        return True
-
-    return False
+    return "~" in filename and ".html" in filename
 
 
 def main() -> int:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,7 +76,6 @@ select = [
 ignore = [
     "E501", # line too long (handled by formatter)
     "SIM102", # Allow nested ifs for clarity
-    "SIM103", # Allow if-else instead of direct return for clarity
     "SIM108", # Allow if-else instead of ternary for clarity
 ]
 


### PR DESCRIPTION
Remove the SIM103 (flake8-simplify) rule from the ignore list and refactor the code to follow the simplified pattern.

Changes:
- Remove SIM103 from pyproject.toml ignore list
- Simplify boolean return in extract_type_info.py:428 Changed from if/else pattern to direct return of boolean expression