### PR TITLE
Phase 120: resolve programming-guide API-reference links to shipping files

### DIFF
--- a/120_export_llm_docs/README.md
+++ b/120_export_llm_docs/README.md
@@ -64,6 +64,7 @@ output/
 5. **Index files**: Category/assembly organization preserved as queryable markdown
 6. **YAML frontmatter**: Every file has metadata (type, assembly, category, kind)
 7. **Simplified cross-references**: `[[IModelDoc2]]` instead of `<see cref="...">`
+8. **Resolved guide links**: API-reference links in the programming guide (e.g. `[IWizardHoleFeatureData2::InitializeHole](../../types/IWizardHoleFeatureData2/InitializeHole.md)`) are rewritten from the original `.html` reference pages to the shipping `types/`/`enums/` files — matched case-insensitively so source-doc typos still resolve; targets not in the bundle fall back to the online help page
 
 ## Markdown Format
 

--- a/120_export_llm_docs/export_pipeline.py
+++ b/120_export_llm_docs/export_pipeline.py
@@ -119,6 +119,9 @@ class ExportPipeline:
         print("\n[7/9] Copying programming guide...")
         for root in self.guide_roots:
             self._copy_programming_guide(root)
+        # Resolve the API-reference links Phase 110 left pointing at the original
+        # ``.html`` pages so they target the ``types/``/``enums/`` files we ship.
+        self._rewrite_guide_api_links(types, self._api_base_url())
 
         # Step 8: Generate output README for LLMs
         print("\n[8/9] Generating output README...")
@@ -275,6 +278,97 @@ class ExportPipeline:
                     self.stats.programming_guide_files += 1
 
         print(f"  Copied {self.stats.programming_guide_files} programming guide files")
+
+    def _api_base_url(self) -> str:
+        """Online help base URL (``https://help.solidworks.com/2026/english/api/``).
+
+        Derived from a guide manifest's ``original_url`` so the version year is not
+        hard-coded; falls back to the 2026 base if no manifest is available.
+        """
+        default = "https://help.solidworks.com/2026/english/api/"
+        for root in self.guide_roots:
+            manifest = Path(root).parent.parent / "metadata" / "files_created.jsonl"
+            if not manifest.exists():
+                continue
+            with open(manifest, encoding="utf-8") as f:
+                for line in f:
+                    url = json.loads(line).get("original_url", "")
+                    idx = url.find("/api/")
+                    if idx != -1:
+                        return f"https://help.solidworks.com{url[:idx + 5]}"
+            break
+        return default
+
+    def _rewrite_guide_api_links(self, types: Dict[str, TypeInfo], base_url: str) -> None:
+        """Resolve API-reference links in the copied programming guide.
+
+        Phase 110 leaves ``sldworksapi``/``swconst``/… reference links pointing at
+        the original ``.html`` pages (it has no knowledge of the reference tree
+        Phase 120 generates). This rewrites each such link to the shipping
+        ``types/{Type}/{Member}.md``, ``types/{Type}/_overview.md`` or
+        ``enums/{Enum}.md`` file, matching type/member names case-insensitively so
+        source-doc typos (e.g. ``IWizardHoleFeatureDAta2``) still resolve. Links
+        whose target does not ship in the bundle are pointed at the online help
+        page instead of a dead relative path.
+        """
+        import posixpath
+        import re
+        from markdown_generator import parse_api_ref_url
+
+        # Case-insensitive indexes over the shipping API-reference tree.
+        type_idx: Dict[str, tuple] = {}       # type_lower -> (sanitized name, is_enum)
+        member_idx: Dict[tuple, str] = {}     # (type_lower, member_lower) -> filename
+        for t in types.values():
+            type_idx[t.name.lower()] = (sanitize_filename(t.name), t.is_enum)
+            if t.is_enum:
+                continue
+            for m in list(t.properties) + list(t.methods):
+                member_idx[(t.name.lower(), m.name.lower())] = sanitize_filename(m.name)
+
+        docs_root = self.output_base / "docs"
+        if not docs_root.exists():
+            return
+
+        link_re = re.compile(r'(\[[^\]]+\]\()<?([^)>]+?\.html?)>?(\))')
+        resolved = external = 0
+
+        for md_file in docs_root.rglob("*.md"):
+            guide_dir = posixpath.dirname(md_file.relative_to(self.output_base).as_posix())
+            state = {"changed": False}
+
+            def repl(match: "re.Match[str]") -> str:
+                nonlocal resolved, external
+                head, url, tail = match.group(1), match.group(2), match.group(3)
+                parsed = parse_api_ref_url(url)
+                if parsed is None:
+                    return match.group(0)
+
+                assembly, type_name, member_name = parsed
+                entry = type_idx.get(type_name.lower())
+                if entry:
+                    sanitized_type, is_enum = entry
+                    if is_enum:
+                        target = f"enums/{sanitized_type}.md"
+                    elif member_name and (type_name.lower(), member_name.lower()) in member_idx:
+                        member_file = member_idx[(type_name.lower(), member_name.lower())]
+                        target = f"types/{sanitized_type}/{member_file}.md"
+                    else:
+                        target = f"types/{sanitized_type}/_overview.md"
+                    resolved += 1
+                    state["changed"] = True
+                    return f"{head}{posixpath.relpath(target, guide_dir)}{tail}"
+
+                # Not in the bundle: link the canonical online page, not a dead path.
+                basename = url.split('?')[0].split('#')[0].split('/')[-1]
+                external += 1
+                state["changed"] = True
+                return f"{head}{base_url}{assembly}/{basename}{tail}"
+
+            new_content = link_re.sub(repl, md_file.read_text(encoding="utf-8"))
+            if state["changed"]:
+                md_file.write_text(new_content, encoding="utf-8")
+
+        print(f"  Rewrote programming-guide API links: {resolved} in-bundle, {external} external")
 
     def _generate_output_readme(self, types: Dict[str, TypeInfo], examples: Dict[str, ExampleContent]):
         """Generate a README.md in the output folder explaining how to consume the docs."""

--- a/120_export_llm_docs/markdown_generator.py
+++ b/120_export_llm_docs/markdown_generator.py
@@ -50,6 +50,39 @@ def guide_link_key(url: str) -> str:
     return url.split('?')[0].rstrip('/').split('/')[-1].lower()
 
 
+def parse_api_ref_url(url: str) -> "Optional[tuple[str, str, Optional[str]]]":
+    """Parse a SolidWorks API-reference URL into ``(assembly, type, member)``.
+
+    Reference pages are named ``{Namespace}~{Namespace}.{Type}[~{Member}].html``
+    and live under an assembly folder (``sldworksapi``, ``swconst``, …). Returns
+    ``None`` when the basename has no ``~`` — the reliable marker that separates
+    reference pages from example/programming-guide pages in those same folders.
+
+    Example::
+
+        .../sldworksapi/SolidWorks.interop.sldworks~SolidWorks.interop.sldworks.IFeature~ModifyDefinition.html
+        -> ("sldworksapi", "IFeature", "ModifyDefinition")
+        .../sldworksapi/SolidWorks.interop.sldworks~SolidWorks.interop.sldworks.IMacroFeatureData.html
+        -> ("sldworksapi", "IMacroFeatureData", None)
+    """
+    path = url.split('?')[0].split('#')[0]
+    segments = [s for s in path.split('/') if s]
+    if not segments:
+        return None
+    basename = re.sub(r'\.html?$', '', segments[-1], flags=re.IGNORECASE)
+    if '~' not in basename:
+        return None
+    parts = basename.split('~')
+    if len(parts) < 2:
+        return None
+    assembly = segments[-2] if len(segments) >= 2 else ''
+    type_name = parts[1].rsplit('.', 1)[-1]
+    member_name = parts[2] if len(parts) > 2 else None
+    if not type_name:
+        return None
+    return assembly, type_name, member_name
+
+
 def simplify_cross_references(text: str, guide_links: Optional[Dict[str, str]] = None,
                              rel_prefix: str = "") -> str:
     """Convert inline XML-style cross-references to markdown/wiki links.

--- a/120_export_llm_docs/tests/test_guide_api_links.py
+++ b/120_export_llm_docs/tests/test_guide_api_links.py
@@ -1,0 +1,132 @@
+"""
+Tests for resolving programming-guide API-reference links (Phase 120).
+
+Phase 110 leaves ``sldworksapi``/``swconst``/… reference links pointing at the
+original ``.html`` pages; Phase 120 must rewrite them to the ``types/``/``enums/``
+files it ships (case-insensitively, so source-doc typos still resolve) and fall
+back to the online help page when the target is not in the bundle.
+"""
+
+import sys
+from pathlib import Path
+import tempfile
+
+# Add parent directory to path
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from models import TypeInfo, Property, Method, EnumMember
+from markdown_generator import parse_api_ref_url
+from export_pipeline import ExportPipeline
+
+
+SLD = "SolidWorks.interop.sldworks~SolidWorks.interop.sldworks"
+
+
+def test_parse_member_url():
+    """Type~Member reference resolves to (assembly, type, member)."""
+    url = f"../../sldworksapi/{SLD}.IFeature~ModifyDefinition.html"
+    assert parse_api_ref_url(url) == ("sldworksapi", "IFeature", "ModifyDefinition")
+
+
+def test_parse_type_only_url():
+    """A bare type page has no member component."""
+    url = f"../../sldworksapi/{SLD}.IMacroFeatureData.html"
+    assert parse_api_ref_url(url) == ("sldworksapi", "IMacroFeatureData", None)
+
+
+def test_parse_enum_url_other_assembly():
+    """Enum pages in other assemblies parse the same way."""
+    url = ("../../swconst/SolidWorks.Interop.swconst~"
+           "SolidWorks.Interop.swconst.swFeatureNameID_e.html")
+    assert parse_api_ref_url(url) == ("swconst", "swFeatureNameID_e", None)
+
+
+def test_parse_non_reference_url_returns_none():
+    """Example/guide pages (no ``~`` in the basename) are not reference pages."""
+    assert parse_api_ref_url("../../sldworksapi/Create_Advanced_Hole_Example_CSharp.htm") is None
+    assert parse_api_ref_url("Welcome.htm") is None
+
+
+def _make_types():
+    """A regular type with a member, plus an enum."""
+    hole = TypeInfo(name="IWizardHoleFeatureData2",
+                    assembly="SolidWorks.Interop.sldworks",
+                    namespace="SolidWorks.Interop.sldworks")
+    hole.methods.append(Method(name="InitializeHole"))
+
+    feat = TypeInfo(name="IFeature",
+                    assembly="SolidWorks.Interop.sldworks",
+                    namespace="SolidWorks.Interop.sldworks")
+    feat.methods.append(Method(name="GetDefinition"))
+
+    enum = TypeInfo(name="swFeatureNameID_e",
+                    assembly="SolidWorks.Interop.swconst",
+                    namespace="SolidWorks.Interop.swconst")
+    enum.enum_members.append(EnumMember(name="swFeatureBoss", description=""))
+
+    return {t.fully_qualified_name: t for t in (hole, feat, enum)}
+
+
+def _write_guide(tmp: Path, body: str) -> Path:
+    guide = tmp / "docs" / "Programming with the SOLIDWORKS API" / "Hole Wizard Features and Objects.md"
+    guide.parent.mkdir(parents=True, exist_ok=True)
+    guide.write_text(body, encoding="utf-8")
+    return guide
+
+
+def test_rewrite_resolves_member_typo_to_md():
+    """The reported case: a typo'd member link resolves to the shipping .md file."""
+    with tempfile.TemporaryDirectory() as td:
+        tmp = Path(td)
+        # Note the source typo: IWizardHoleFeatureDAta2 (capital A).
+        guide = _write_guide(
+            tmp,
+            f"Init using [IWizardHoleFeatureData2::InitializeHole.]"
+            f"(../../sldworksapi/{SLD}.IWizardHoleFeatureDAta2~InitializeHole.html)\n",
+        )
+
+        ExportPipeline(str(tmp))._rewrite_guide_api_links(
+            _make_types(), "https://help.solidworks.com/2026/english/api/")
+
+        text = guide.read_text(encoding="utf-8")
+        assert "(../../types/IWizardHoleFeatureData2/InitializeHole.md)" in text
+        assert ".html)" not in text
+
+
+def test_rewrite_type_only_and_enum_and_external():
+    with tempfile.TemporaryDirectory() as td:
+        tmp = Path(td)
+        guide = _write_guide(
+            tmp,
+            "\n".join([
+                f"[type](../../sldworksapi/{SLD}.IFeature.html)",
+                f"[method](../../sldworksapi/{SLD}.IFeature~GetDefinition.html)",
+                ("[enum](../../swconst/SolidWorks.Interop.swconst~"
+                 "SolidWorks.Interop.swconst.swFeatureNameID_e.html)"),
+                f"[missing](../../sldworksapi/{SLD}.INotShipped~DoThing.html)",
+                "",
+            ]),
+        )
+
+        ExportPipeline(str(tmp))._rewrite_guide_api_links(
+            _make_types(), "https://help.solidworks.com/2026/english/api/")
+
+        text = guide.read_text(encoding="utf-8")
+        assert "[type](../../types/IFeature/_overview.md)" in text
+        assert "[method](../../types/IFeature/GetDefinition.md)" in text
+        assert "[enum](../../enums/swFeatureNameID_e.md)" in text
+        # Unresolved target -> canonical online page, not a dead relative path.
+        assert ("[missing](https://help.solidworks.com/2026/english/api/sldworksapi/"
+                f"{SLD}.INotShipped~DoThing.html)") in text
+
+
+def test_rewrite_leaves_non_reference_links_untouched():
+    with tempfile.TemporaryDirectory() as td:
+        tmp = Path(td)
+        original = "[sibling guide](Other%20Page.md) and [ex](../../sldworksapi/Some_Example.htm)\n"
+        guide = _write_guide(tmp, original)
+
+        ExportPipeline(str(tmp))._rewrite_guide_api_links(
+            _make_types(), "https://help.solidworks.com/2026/english/api/")
+
+        assert guide.read_text(encoding="utf-8") == original


### PR DESCRIPTION
## Problem

The programming guide shipped under `docs/` carried ~2135 **dead** API-reference links per bundle. Phase 110 leaves `sldworksapi`/`swconst`/… reference links pointing at the original `.html` pages (it has no knowledge of the `types/`/`enums/` tree Phase 120 generates), and `_copy_programming_guide` copied those files verbatim.

The reported case (`Hole Wizard Features and Objects.md`):

```
[IWizardHoleFeatureData2::InitializeHole.](../../sldworksapi/…IWizardHoleFeatureDAta2~InitializeHole.html)
```

— wrong path (`sldworksapi/` vs `types/`), wrong extension (`.html` vs `.md`), and a source-doc typo (`DAta2`) the online page shares. The target `types/IWizardHoleFeatureData2/InitializeHole.md` ships in the bundle but nothing linked to it.

## Fix

A rewrite pass after the guide copy resolves each reference link to the shipping `types/{Type}/{Member}.md`, `types/{Type}/_overview.md`, or `enums/{Enum}.md` file. Type/member names are matched **case-insensitively**, so source-doc typos still resolve. Targets not in the bundle fall back to the canonical **online help URL** instead of a dead relative path.

## Verification (real data)

Loaded the committed phase-20/40/50/60 data (1525 types) and ran the resolver over the real shipped programming guide:

| metric | before | after |
|---|---|---|
| relative `~.html` reference links | 2135 | **0** |
| → resolved into `types/`/`enums/` `.md` | – | 2089 |
| → online help fallback (not shipped) | – | 46 |

All 2089 resolved links verified to land at valid bundle-root paths (correct `../` depth for nested guide files). The reported line now reads:

```
[IWizardHoleFeatureData2::InitializeHole.](../../types/IWizardHoleFeatureData2/InitializeHole.md)
```

New unit tests cover URL parsing (member/type-only/enum/non-reference), the typo-recovery case, and the type/enum/external branches. Full Phase 120 suite (29 tests) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)