### PR TITLE
Phase 120: address Codex review of guide-link rewrite (3 P2 edge cases)

### DIFF
--- a/120_export_llm_docs/export_pipeline.py
+++ b/120_export_llm_docs/export_pipeline.py
@@ -329,7 +329,8 @@ class ExportPipeline:
         if not docs_root.exists():
             return
 
-        link_re = re.compile(r'(\[[^\]]+\]\()<?([^)>]+?\.html?)>?(\))')
+        # Allow a #fragment or ?query after the extension (parse_api_ref_url strips them).
+        link_re = re.compile(r'(\[[^\]]+\]\()<?([^)>]+?\.html?(?:[?#][^)>]*)?)>?(\))')
         resolved = external = 0
 
         for md_file in docs_root.rglob("*.md"):
@@ -347,22 +348,32 @@ class ExportPipeline:
                 entry = type_idx.get(type_name.lower())
                 if entry:
                     sanitized_type, is_enum = entry
+                    target = None
                     if is_enum:
                         target = f"enums/{sanitized_type}.md"
-                    elif member_name and (type_name.lower(), member_name.lower()) in member_idx:
+                    elif member_name is None:
+                        target = f"types/{sanitized_type}/_overview.md"
+                    elif (type_name.lower(), member_name.lower()) in member_idx:
                         member_file = member_idx[(type_name.lower(), member_name.lower())]
                         target = f"types/{sanitized_type}/{member_file}.md"
-                    else:
-                        target = f"types/{sanitized_type}/_overview.md"
-                    resolved += 1
-                    state["changed"] = True
-                    return f"{head}{posixpath.relpath(target, guide_dir)}{tail}"
+                    # A named member the type does not export (obsolete/typoed) has no
+                    # file to point at — fall through to the canonical online page
+                    # rather than silently redirecting to the type overview.
+                    if target:
+                        resolved += 1
+                        state["changed"] = True
+                        return f"{head}{posixpath.relpath(target, guide_dir)}{tail}"
 
                 # Not in the bundle: link the canonical online page, not a dead path.
+                # Same-directory references carry no assembly segment in the URL; recover
+                # it from the referenced page's own folder so the URL is not malformed.
+                asm = assembly or posixpath.basename(guide_dir)
+                if not asm or asm == "docs":
+                    return match.group(0)
                 basename = url.split('?')[0].split('#')[0].split('/')[-1]
                 external += 1
                 state["changed"] = True
-                return f"{head}{base_url}{assembly}/{basename}{tail}"
+                return f"{head}{base_url}{asm}/{basename}{tail}"
 
             new_content = link_re.sub(repl, md_file.read_text(encoding="utf-8"))
             if state["changed"]:

--- a/120_export_llm_docs/tests/test_guide_api_links.py
+++ b/120_export_llm_docs/tests/test_guide_api_links.py
@@ -120,6 +120,56 @@ def test_rewrite_type_only_and_enum_and_external():
                 f"{SLD}.INotShipped~DoThing.html)") in text
 
 
+def test_missing_member_falls_back_to_online_page():
+    """A member the type does not export lands on the online page, not the overview."""
+    with tempfile.TemporaryDirectory() as td:
+        tmp = Path(td)
+        guide = _write_guide(
+            tmp,
+            f"[gone](../../sldworksapi/{SLD}.IFeature~ObsoleteMethod.html)\n",
+        )
+        ExportPipeline(str(tmp))._rewrite_guide_api_links(
+            _make_types(), "https://help.solidworks.com/2026/english/api/")
+
+        text = guide.read_text(encoding="utf-8")
+        assert "_overview.md" not in text
+        assert ("[gone](https://help.solidworks.com/2026/english/api/sldworksapi/"
+                f"{SLD}.IFeature~ObsoleteMethod.html)") in text
+
+
+def test_reference_link_with_fragment_resolves():
+    """A #fragment (or ?query) after .html still resolves to the member file."""
+    with tempfile.TemporaryDirectory() as td:
+        tmp = Path(td)
+        guide = _write_guide(
+            tmp,
+            f"[m](../../sldworksapi/{SLD}.IFeature~GetDefinition.html#remarks)\n",
+        )
+        ExportPipeline(str(tmp))._rewrite_guide_api_links(
+            _make_types(), "https://help.solidworks.com/2026/english/api/")
+
+        assert "[m](../../types/IFeature/GetDefinition.md)" in guide.read_text(encoding="utf-8")
+
+
+def test_basename_only_unresolved_recovers_assembly_from_folder():
+    """A same-directory ref with no assembly segment must not emit a `//` URL."""
+    with tempfile.TemporaryDirectory() as td:
+        tmp = Path(td)
+        # Referenced pages live under docs/{assembly}/; the link has no path prefix.
+        ref = tmp / "docs" / "sldworksapi" / "SomePage.md"
+        ref.parent.mkdir(parents=True, exist_ok=True)
+        ref.write_text(
+            f"[x]({SLD.replace('interop', 'Interop')}.INotShipped.html)\n",
+            encoding="utf-8",
+        )
+        ExportPipeline(str(tmp))._rewrite_guide_api_links(
+            _make_types(), "https://help.solidworks.com/2026/english/api/")
+
+        text = ref.read_text(encoding="utf-8")
+        assert "api//" not in text
+        assert "https://help.solidworks.com/2026/english/api/sldworksapi/" in text
+
+
 def test_rewrite_leaves_non_reference_links_untouched():
     with tempfile.TemporaryDirectory() as td:
         tmp = Path(td)


### PR DESCRIPTION
Follow-up to #16, addressing all 3 Codex P2 findings. Verified each against the real corpus first (2135 API-ref links).

| # | Finding | Real occurrences | Fix |
|---|---|---|---|
| 1 | Missing member → silently rewritten to `_overview.md` and counted resolved | 0 (defensive) | Reserve overview for type-only links; a named-but-unexported member takes the online-page fallback |
| 2 | Links with `#fragment`/`?query` after `.html` never matched → left dead | 0 (defensive) | Regex allows an optional `#…`/`?…` suffix (`parse_api_ref_url` already strips it) |
| 3 | Same-dir ref with no assembly segment → malformed `.../api//SolidWorks…` URL | **2** | Recover the assembly from the referenced page's own folder |

## Verification
Regenerated Phase 120: **0** dead relative `~.html` links, **0** malformed `//` URLs (was 2), `validate_export` passes. Test suite 32 passing (3 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)