### PR TITLE
Fix flattened markdown in remarks/params (lists, headings, bold)

### DIFF
--- a/120_export_llm_docs/markdown_generator.py
+++ b/120_export_llm_docs/markdown_generator.py
@@ -31,6 +31,14 @@ def _block(lines: List[str]) -> str:
     return "\n".join(lines) + "\n"
 
 
+def _indent_continuation(text: str, indent: str = "  ") -> str:
+    """Indent every line after the first so a multi-line value renders as the
+    continuation of a ``- `` list item (nested paragraphs/sublists stay under
+    the bullet instead of escaping it). Blank lines are left empty."""
+    lines = text.split("\n")
+    return "\n".join(lines[:1] + [f"{indent}{line}" if line else line for line in lines[1:]])
+
+
 def clean_text(text: str) -> str:
     """Clean raw XML text: unescape HTML entities, drop CDATA markers, and
     collapse runs of blank lines so paragraphs are separated by at most one."""
@@ -221,8 +229,10 @@ class MarkdownGenerator:
                 if prop.parameters:
                     md.append("**Parameters**:\n")
                     md.append(_block([
-                        f"- `{param.name}` - "
-                        f"{self._clean_text(param.description) if param.description else 'No description'}"
+                        _indent_continuation(
+                            f"- `{param.name}` - "
+                            f"{self._clean_text(param.description) if param.description else 'No description'}"
+                        )
                         for param in prop.parameters
                     ]))
 
@@ -247,8 +257,10 @@ class MarkdownGenerator:
                 if method.parameters:
                     md.append("**Parameters**:\n")
                     md.append(_block([
-                        f"- `{param.name}` - "
-                        f"{self._clean_text(param.description) if param.description else 'No description'}"
+                        _indent_continuation(
+                            f"- `{param.name}` - "
+                            f"{self._clean_text(param.description) if param.description else 'No description'}"
+                        )
                         for param in method.parameters
                     ]))
 
@@ -505,8 +517,10 @@ class MarkdownGenerator:
         if member.parameters:
             md.append("## Parameters\n")
             md.append(_block([
-                f"- **{param.name}**: "
-                f"{self._simplify_cross_references(self._clean_text(param.description), rel_prefix) if param.description else 'No description'}"
+                _indent_continuation(
+                    f"- **{param.name}**: "
+                    f"{self._simplify_cross_references(self._clean_text(param.description), rel_prefix) if param.description else 'No description'}"
+                )
                 for param in member.parameters
             ]))
 

--- a/120_export_llm_docs/markdown_generator.py
+++ b/120_export_llm_docs/markdown_generator.py
@@ -39,6 +39,35 @@ def _indent_continuation(text: str, indent: str = "  ") -> str:
     return "\n".join(lines[:1] + [f"{indent}{line}" if line else line for line in lines[1:]])
 
 
+# A converted value that opens with a list bullet or heading is block markdown:
+# it must not be pasted inline after a label (``- **Param**: - A``), or the first
+# element is swallowed as literal text instead of starting a list/heading.
+_STARTS_WITH_BLOCK = re.compile(r"\s*(?:[-*] |\d+\. |#{1,6} )")
+
+
+def _indent_all(text: str, indent: str = "  ") -> str:
+    """Indent every non-empty line by ``indent`` (blank lines stay empty)."""
+    return "\n".join(f"{indent}{line}" if line else line for line in text.split("\n"))
+
+
+def _labeled_bullet(prefix: str, content: str) -> str:
+    """Render ``{prefix}{content}`` as a ``- `` list item. If ``content`` starts
+    with block markdown, drop it onto indented continuation lines under the label
+    (``- **Param**:\\n  - A``) instead of inlining it (``- **Param**: - A``)."""
+    if _STARTS_WITH_BLOCK.match(content):
+        return f"{prefix.rstrip()}\n{_indent_all(content)}"
+    return _indent_continuation(f"{prefix}{content}")
+
+
+def _labeled_field(label: str, value: str) -> str:
+    """Render a top-level ``{label} {value}`` field. If ``value`` starts with
+    block markdown, break it onto its own block after the label so the first
+    list item / heading isn't consumed as inline text."""
+    if _STARTS_WITH_BLOCK.match(value):
+        return f"{label}\n\n{value}"
+    return f"{label} {value}"
+
+
 def clean_text(text: str) -> str:
     """Clean raw XML text: unescape HTML entities, drop CDATA markers, and
     collapse runs of blank lines so paragraphs are separated by at most one."""
@@ -229,18 +258,18 @@ class MarkdownGenerator:
                 if prop.parameters:
                     md.append("**Parameters**:\n")
                     md.append(_block([
-                        _indent_continuation(
-                            f"- `{param.name}` - "
-                            f"{self._clean_text(param.description) if param.description else 'No description'}"
+                        _labeled_bullet(
+                            f"- `{param.name}` - ",
+                            self._clean_text(param.description) if param.description else 'No description'
                         )
                         for param in prop.parameters
                     ]))
 
                 if prop.returns:
-                    md.append(f"**Returns**: {self._clean_text(prop.returns)}\n")
+                    md.append(f"{_labeled_field('**Returns**:', self._clean_text(prop.returns))}\n")
 
                 if prop.remarks:
-                    md.append(f"**Remarks**: {self._clean_text(prop.remarks)}\n")
+                    md.append(f"{_labeled_field('**Remarks**:', self._clean_text(prop.remarks))}\n")
 
         # Methods
         if type_info.methods:
@@ -257,18 +286,18 @@ class MarkdownGenerator:
                 if method.parameters:
                     md.append("**Parameters**:\n")
                     md.append(_block([
-                        _indent_continuation(
-                            f"- `{param.name}` - "
-                            f"{self._clean_text(param.description) if param.description else 'No description'}"
+                        _labeled_bullet(
+                            f"- `{param.name}` - ",
+                            self._clean_text(param.description) if param.description else 'No description'
                         )
                         for param in method.parameters
                     ]))
 
                 if method.returns:
-                    md.append(f"**Returns**: {self._clean_text(method.returns)}\n")
+                    md.append(f"{_labeled_field('**Returns**:', self._clean_text(method.returns))}\n")
 
                 if method.remarks:
-                    md.append(f"**Remarks**: {self._clean_text(method.remarks)}\n")
+                    md.append(f"{_labeled_field('**Remarks**:', self._clean_text(method.remarks))}\n")
 
         # Examples
         if type_info.examples:
@@ -517,9 +546,9 @@ class MarkdownGenerator:
         if member.parameters:
             md.append("## Parameters\n")
             md.append(_block([
-                _indent_continuation(
-                    f"- **{param.name}**: "
-                    f"{self._simplify_cross_references(self._clean_text(param.description), rel_prefix) if param.description else 'No description'}"
+                _labeled_bullet(
+                    f"- **{param.name}**: ",
+                    self._simplify_cross_references(self._clean_text(param.description), rel_prefix) if param.description else 'No description'
                 )
                 for param in member.parameters
             ]))

--- a/120_export_llm_docs/tests/test_grep_optimized_export.py
+++ b/120_export_llm_docs/tests/test_grep_optimized_export.py
@@ -108,6 +108,37 @@ def test_member_documentation_generation():
     print("[PASS] Member documentation generation with YAML frontmatter")
 
 
+def test_multiline_param_description_indented_under_bullet():
+    """A parameter whose description carries block markdown (a sublist, extra
+    paragraphs) must keep its continuation lines indented under the ``- `` bullet
+    so it renders as one list item instead of escaping the list."""
+    from models import Parameter
+
+    type_info = TypeInfo(
+        name="IFeatureManager",
+        assembly="SolidWorks.Interop.sldworks",
+        namespace="SolidWorks.Interop.sldworks",
+    )
+    method = Method(name="HoleWizard5", description="Creates holes.")
+    method.parameters.append(Parameter(
+        name="Length",
+        description="Length of slot; valid only if GenericHoleType set to:\n\n- swWzdCounterBoreSlot\n- swWzdHoleSlot",
+    ))
+    method.parameters.append(Parameter(name="Depth", description="Depth of the hole"))
+
+    generator = MarkdownGenerator(output_base_path="test", grep_optimized=True)
+    member_md = generator.generate_member_documentation(type_info, method, "method")
+
+    # The sublist items are indented two spaces so they nest under "- **Length**".
+    assert "- **Length**: Length of slot" in member_md
+    assert "\n  - swWzdCounterBoreSlot" in member_md
+    assert "\n  - swWzdHoleSlot" in member_md
+    # The next parameter is a sibling bullet, not indented.
+    assert "\n- **Depth**: Depth of the hole" in member_md
+
+    print("[PASS] Multi-line parameter description indented under its bullet")
+
+
 def test_enum_documentation_generation():
     """Test that a single enum file is generated with all members inline."""
     # Create a sample enum type

--- a/120_export_llm_docs/tests/test_grep_optimized_export.py
+++ b/120_export_llm_docs/tests/test_grep_optimized_export.py
@@ -139,6 +139,54 @@ def test_multiline_param_description_indented_under_bullet():
     print("[PASS] Multi-line parameter description indented under its bullet")
 
 
+def test_param_description_starting_with_list_nests_under_bullet():
+    """A parameter whose description *starts* with a list must not inline the
+    first item after the label (``- **P**: - A``); it goes on indented lines."""
+    from models import Parameter
+
+    type_info = TypeInfo(
+        name="IAssemblyDoc",
+        assembly="SolidWorks.Interop.sldworks",
+        namespace="SolidWorks.Interop.sldworks",
+    )
+    method = Method(name="CompConfigProperties5", description="Sets config properties.")
+    method.parameters.append(Parameter(
+        name="RefConfigName",
+        description="- If a non-empty string is specified, the named config is used\n- If empty, the default is used",
+    ))
+
+    generator = MarkdownGenerator(output_base_path="test", grep_optimized=True)
+    member_md = generator.generate_member_documentation(type_info, method, "method")
+
+    assert "- **RefConfigName**:\n" in member_md          # label on its own line
+    assert "\n  - If a non-empty string" in member_md      # list nested under it
+    assert "- **RefConfigName**: -" not in member_md       # never inlined
+    print("[PASS] List-first parameter description nests under its bullet")
+
+
+def test_block_return_value_not_inlined_after_label():
+    """In the monolithic format, a return/remarks value that is block markdown
+    must break onto its own block instead of ``**Returns**: - A``."""
+    type_info = TypeInfo(
+        name="IThing",
+        assembly="SolidWorks.Interop.sldworks",
+        namespace="SolidWorks.Interop.sldworks",
+    )
+    type_info.methods.append(Method(
+        name="DoIt",
+        returns="- first outcome\n- second outcome",
+        remarks="Plain remark.",
+    ))
+
+    generator = MarkdownGenerator(output_base_path="test", grep_optimized=False)
+    md = generator.generate_type_documentation(type_info)
+
+    assert "**Returns**:\n\n- first outcome" in md
+    assert "**Returns**: -" not in md
+    assert "**Remarks**: Plain remark." in md   # non-block value stays inline
+    print("[PASS] Block return value rendered as a block, not inline")
+
+
 def test_enum_documentation_generation():
     """Test that a single enum file is generated with all members inline."""
     # Create a sample enum type

--- a/50_extract_type_member_details/extract_member_details.py
+++ b/50_extract_type_member_details/extract_member_details.py
@@ -104,10 +104,14 @@ class MemberDetailsExtractor(HTMLParser):
                 self.in_description = False
             return
 
-        # Track when we're inside an h4 tag
+        # Track when we're inside an h4 tag. Inside remarks, <h4> marks a real
+        # subheading (e.g. "Counterbore Holes and Slots"), so fall through to the
+        # remarks tag collector below to keep it; elsewhere it is only a section
+        # sentinel and is dropped.
         if tag == "h4":
             self.in_h4 = True
-            return
+            if not self.in_remarks_section:
+                return
 
         # Detect C# syntax section for signature extraction
         if tag == "div" and attrs_dict.get("id") == "Syntax_CS":

--- a/50_extract_type_member_details/tests/test_extract_member_details.py
+++ b/50_extract_type_member_details/tests/test_extract_member_details.py
@@ -311,6 +311,26 @@ class TestMemberDetailsExtractor:
 
         assert "dialog" in parser.get_remarks()
 
+    def test_remarks_subheadings_become_markdown_headings(self):
+        """<h4> subheadings inside remarks are kept and rendered as markdown
+        headings (they used to be dropped, flattening them into plain text)."""
+        html = """
+        <h1>Remarks</h1>
+        <div id="remarksSection">
+            <p>Intro.</p>
+            <h4>Counterbore Holes and Slots</h4>
+            <ol><li>CounterBore Diameter</li><li>CounterBore Depth</li></ol>
+        </div>
+        <h1>See Also</h1>
+        """
+        parser = MemberDetailsExtractor()
+        parser.feed(html)
+
+        remarks = parser.get_remarks()
+        assert "#### Counterbore Holes and Slots" in remarks
+        assert "1. CounterBore Diameter" in remarks
+        assert "2. CounterBore Depth" in remarks
+
     def test_extract_remarks_with_nested_divs(self):
         """Remarks must not truncate at the first nested <div> that closes.
 

--- a/shared/tests/test_xmldoc_links.py
+++ b/shared/tests/test_xmldoc_links.py
@@ -128,6 +128,61 @@ class TestConvertLinksToSeeRefs(unittest.TestCase):
         self.assertIn("<see cref=", result)
 
 
+class TestHtmlStructureToMarkdown(unittest.TestCase):
+    """Structural HTML in help text is converted to markdown, not flattened."""
+
+    def test_unordered_list_becomes_bullets(self):
+        result = convert_links_to_see_refs("<ul><li>First</li><li>Second</li></ul>")
+        self.assertIn("- First", result)
+        self.assertIn("- Second", result)
+
+    def test_ordered_list_is_numbered(self):
+        result = convert_links_to_see_refs("<ol><li>Alpha</li><li>Beta</li><li>Gamma</li></ol>")
+        self.assertIn("1. Alpha", result)
+        self.assertIn("2. Beta", result)
+        self.assertIn("3. Gamma", result)
+
+    def test_paragraphs_separated_by_blank_line(self):
+        result = convert_links_to_see_refs("<p>One.</p><p>Two.</p>")
+        self.assertEqual(result, "One.\n\nTwo.")
+
+    def test_heading_becomes_markdown_heading(self):
+        result = convert_links_to_see_refs("<h4>Counterbore Holes</h4><p>Body.</p>")
+        self.assertIn("#### Counterbore Holes", result)
+
+    def test_bold_becomes_double_asterisks(self):
+        self.assertIn("**Screw Fit**", convert_links_to_see_refs("<strong>Screw Fit</strong>"))
+        self.assertIn("**Screw Fit**", convert_links_to_see_refs("<b>Screw Fit</b>"))
+        self.assertIn(
+            "**Head Clearance**",
+            convert_links_to_see_refs('<span style="FONT-WEIGHT: bold">Head Clearance</span>'),
+        )
+
+    def test_trailing_space_moved_outside_bold(self):
+        """Source often wraps a trailing space inside <strong>; the markers must
+        hug the text so CommonMark still recognises the emphasis."""
+        result = convert_links_to_see_refs("see <strong>Remarks </strong>for details")
+        self.assertIn("**Remarks**", result)
+        self.assertNotIn("**Remarks **", result)
+
+    def test_list_item_wrapping_paragraph_hugs_marker(self):
+        result = convert_links_to_see_refs("<ul><li><p>Wrapped item.</p></li></ul>")
+        self.assertIn("- Wrapped item.", result)
+        self.assertNotIn("- \n", result)
+
+    def test_see_ref_preserved_through_conversion(self):
+        html = ('<ul><li>Use '
+                '<a href="SolidWorks.Interop.sldworks~SolidWorks.Interop.sldworks.IFeature.html">IFeature</a>'
+                '</li></ul>')
+        result = convert_links_to_see_refs(html)
+        self.assertIn('- Use <see cref="SolidWorks.Interop.sldworks.IFeature">IFeature</see>', result)
+
+    def test_nested_list_is_indented(self):
+        result = convert_links_to_see_refs("<ul><li>Outer<ul><li>Inner</li></ul></li></ul>")
+        self.assertIn("- Outer", result)
+        self.assertIn("  - Inner", result)
+
+
 class TestHrefToSeeRef(unittest.TestCase):
     """Test resolving See Also hrefs to (attr, value) tuples."""
 

--- a/shared/tests/test_xmldoc_links.py
+++ b/shared/tests/test_xmldoc_links.py
@@ -182,6 +182,28 @@ class TestHtmlStructureToMarkdown(unittest.TestCase):
         self.assertIn("- Outer", result)
         self.assertIn("  - Inner", result)
 
+    def test_second_paragraph_in_list_item_is_indented(self):
+        """A list item with two paragraphs keeps the second one indented under
+        the marker so it stays part of the item instead of escaping the list."""
+        result = convert_links_to_see_refs("<ul><li><p>First</p><p>Second</p></li></ul>")
+        self.assertIn("- First", result)
+        self.assertIn("\n  Second", result)
+        self.assertNotIn("\nSecond", result.replace("\n  Second", ""))
+
+    def test_nested_list_under_two_digit_ordered_item_aligns_to_content_column(self):
+        """A nested list under item 10 must indent 4 spaces (past ``10. ``), not
+        the 2 that would suffice for a single-digit parent, or it escapes."""
+        items = "".join(f"<li>Item {i}</li>" for i in range(1, 10))
+        html = f"<ol>{items}<li>Tenth<ul><li>Nested</li></ul></li></ol>"
+        result = convert_links_to_see_refs(html)
+        self.assertIn("10. Tenth", result)
+        self.assertIn("\n    - Nested", result)
+
+    def test_nested_list_under_single_digit_ordered_item(self):
+        result = convert_links_to_see_refs("<ol><li>Outer<ul><li>Inner</li></ul></li></ol>")
+        self.assertIn("1. Outer", result)
+        self.assertIn("\n   - Inner", result)
+
 
 class TestHrefToSeeRef(unittest.TestCase):
     """Test resolving See Also hrefs to (attr, value) tuples."""

--- a/shared/xmldoc_links.py
+++ b/shared/xmldoc_links.py
@@ -47,8 +47,10 @@ class _HtmlToMarkdown(HTMLParser):
         # stream delivered to handle_data, matching the old manual unescaping.
         super().__init__(convert_charrefs=True)
         self.parts: list[str] = []
-        # Stack of open ordered/unordered lists; each entry tracks its running
-        # item counter so nested ``<ol>`` numbering and indentation stay correct.
+        # Stack of open ordered/unordered lists. Each frame tracks its running
+        # item counter (for ``<ol>`` numbering), ``base_indent`` (the column its
+        # markers sit at) and ``item_indent`` (the content column of the current
+        # item, where continuation paragraphs and nested lists must align).
         self._lists: list[dict[str, object]] = []
         # Parallel stack for <span>: records whether each open span was bold, so
         # the matching </span> knows whether to close a ``**`` run.
@@ -57,6 +59,10 @@ class _HtmlToMarkdown(HTMLParser):
         # <li> (a wrapping <p>/<h4>) hugs the marker instead of starting a blank
         # line, which would leave an empty bullet.
         self._suppress_para = False
+
+    def _cur_indent(self) -> str:
+        """Continuation indent for the innermost open list item (``""`` at top level)."""
+        return str(self._lists[-1]["item_indent"]) if self._lists else ""
 
     def _emit_see(self, tag: str, attrs: list, self_closing: bool) -> None:
         attrs_str = "".join(f' {name}="{value}"' for name, value in attrs)
@@ -70,29 +76,37 @@ class _HtmlToMarkdown(HTMLParser):
             self._emit_see(tag, attrs, self_closing=False)
             return
         if tag == "br":
-            self.parts.append("\n")
+            self.parts.append("\n" + self._cur_indent())
             return
         if tag in _PARAGRAPH_TAGS:
             if not self._suppress_para:
-                self.parts.append("\n\n")
+                self.parts.append("\n\n" + self._cur_indent())
             self._suppress_para = False
             return
         if tag in ("ul", "ol"):
-            self._lists.append({"type": tag, "count": 0})
+            # A nested list's markers align under the content column of the
+            # enclosing item; a top-level list sits at column 0.
+            base = self._cur_indent()
+            self._lists.append({"type": tag, "count": 0, "base_indent": base, "item_indent": base})
             self.parts.append("\n")
             return
         if tag == "li":
-            indent = "  " * max(0, len(self._lists) - 1)
-            if self._lists and self._lists[-1]["type"] == "ol":
-                self._lists[-1]["count"] = int(self._lists[-1]["count"]) + 1
-                marker = f"{self._lists[-1]['count']}. "
+            frame = self._lists[-1] if self._lists else None
+            base = str(frame["base_indent"]) if frame else ""
+            if frame and frame["type"] == "ol":
+                frame["count"] = int(frame["count"]) + 1
+                marker = f"{frame['count']}. "
             else:
                 marker = "- "
-            self.parts.append(f"\n{indent}{marker}")
+            if frame:
+                # Continuation lines / nested lists align under the item's text,
+                # i.e. past the marker (4 cols for "10. ", 3 for "1. ", 2 for "- ").
+                frame["item_indent"] = base + " " * len(marker)
+            self.parts.append(f"\n{base}{marker}")
             self._suppress_para = True
             return
         if re.fullmatch(r"h[1-6]", tag):
-            prefix = "" if self._suppress_para else "\n\n"
+            prefix = "" if self._suppress_para else "\n\n" + self._cur_indent()
             self._suppress_para = False
             self.parts.append(prefix + "#" * int(tag[1]) + " ")
             return
@@ -125,7 +139,7 @@ class _HtmlToMarkdown(HTMLParser):
             self.parts.append("</see>")
             return
         if tag in _PARAGRAPH_TAGS:
-            self.parts.append("\n\n")
+            self.parts.append("\n\n" + self._cur_indent())
             return
         if tag in ("ul", "ol"):
             if self._lists:
@@ -133,7 +147,7 @@ class _HtmlToMarkdown(HTMLParser):
             self.parts.append("\n")
             return
         if re.fullmatch(r"h[1-6]", tag):
-            self.parts.append("\n\n")
+            self.parts.append("\n\n" + self._cur_indent())
             return
         if tag in ("strong", "b"):
             self.parts.append(_B_CLOSE)

--- a/shared/xmldoc_links.py
+++ b/shared/xmldoc_links.py
@@ -7,6 +7,193 @@ and <see href> tags for IntelliSense documentation.
 """
 
 import re
+from html.parser import HTMLParser
+
+
+# Block-level tags that introduce a paragraph break (blank line) in markdown.
+_PARAGRAPH_TAGS = {"p", "div", "blockquote"}
+
+# Distinct open/close sentinels for emphasis. Using placeholders (rather than
+# emitting ``**``/``*`` directly) lets us relocate whitespace out of an emphasis
+# span before committing to the markers, without confusing them with literal
+# asterisks that appear in the source text (e.g. "*not*"). Resolved in
+# :func:`html_to_markdown`.
+_B_OPEN, _B_CLOSE = "\x01", "\x02"
+_I_OPEN, _I_CLOSE = "\x03", "\x04"
+
+
+def _is_bold_span(attrs: dict[str, str]) -> bool:
+    """True if a ``<span>``'s inline style makes its text bold."""
+    style = attrs.get("style", "").lower()
+    return "font-weight" in style and "bold" in style
+
+
+class _HtmlToMarkdown(HTMLParser):
+    """Convert an HTML fragment to markdown, passing ``<see>`` tags through verbatim.
+
+    The SolidWorks help text uses ``<p>``/``<ul>``/``<ol>``/``<li>``/``<h4>``/
+    ``<strong>`` etc. to structure remarks, parameter descriptions and return
+    values. Stripping those tags outright (the old behaviour) flattened lists and
+    paragraphs into run-on text. This converter preserves the structure as
+    markdown so both the XMLDoc and the LLM-markdown exports render it correctly.
+
+    ``<a>`` tags are expected to have already been rewritten to ``<see cref>`` /
+    ``<see href>`` by :func:`convert_links_to_see_refs`; those are re-emitted
+    unchanged so downstream stages can resolve them.
+    """
+
+    def __init__(self) -> None:
+        # convert_charrefs=True decodes entities (&nbsp;, &lt;, …) into the text
+        # stream delivered to handle_data, matching the old manual unescaping.
+        super().__init__(convert_charrefs=True)
+        self.parts: list[str] = []
+        # Stack of open ordered/unordered lists; each entry tracks its running
+        # item counter so nested ``<ol>`` numbering and indentation stay correct.
+        self._lists: list[dict[str, object]] = []
+        # Parallel stack for <span>: records whether each open span was bold, so
+        # the matching </span> knows whether to close a ``**`` run.
+        self._span_bold: list[bool] = []
+        # Set right after a list marker is emitted so the first block child of an
+        # <li> (a wrapping <p>/<h4>) hugs the marker instead of starting a blank
+        # line, which would leave an empty bullet.
+        self._suppress_para = False
+
+    def _emit_see(self, tag: str, attrs: list, self_closing: bool) -> None:
+        attrs_str = "".join(f' {name}="{value}"' for name, value in attrs)
+        if self_closing:
+            self.parts.append(f"<{tag}{attrs_str} />")
+        else:
+            self.parts.append(f"<{tag}{attrs_str}>")
+
+    def handle_starttag(self, tag: str, attrs: list) -> None:
+        if tag == "see":
+            self._emit_see(tag, attrs, self_closing=False)
+            return
+        if tag == "br":
+            self.parts.append("\n")
+            return
+        if tag in _PARAGRAPH_TAGS:
+            if not self._suppress_para:
+                self.parts.append("\n\n")
+            self._suppress_para = False
+            return
+        if tag in ("ul", "ol"):
+            self._lists.append({"type": tag, "count": 0})
+            self.parts.append("\n")
+            return
+        if tag == "li":
+            indent = "  " * max(0, len(self._lists) - 1)
+            if self._lists and self._lists[-1]["type"] == "ol":
+                self._lists[-1]["count"] = int(self._lists[-1]["count"]) + 1
+                marker = f"{self._lists[-1]['count']}. "
+            else:
+                marker = "- "
+            self.parts.append(f"\n{indent}{marker}")
+            self._suppress_para = True
+            return
+        if re.fullmatch(r"h[1-6]", tag):
+            prefix = "" if self._suppress_para else "\n\n"
+            self._suppress_para = False
+            self.parts.append(prefix + "#" * int(tag[1]) + " ")
+            return
+        if tag in ("strong", "b"):
+            self.parts.append(_B_OPEN)
+            return
+        if tag in ("em", "i"):
+            self.parts.append(_I_OPEN)
+            return
+        if tag == "span":
+            bold = _is_bold_span(dict(attrs))
+            self._span_bold.append(bold)
+            if bold:
+                self.parts.append(_B_OPEN)
+            return
+        # tr introduces a new table row; any other tag (td, th, table, font, …)
+        # is dropped but its text content is kept.
+        if tag == "tr":
+            self.parts.append("\n")
+
+    def handle_startendtag(self, tag: str, attrs: list) -> None:
+        if tag == "see":
+            self._emit_see(tag, attrs, self_closing=True)
+            return
+        if tag == "br":
+            self.parts.append("\n")
+
+    def handle_endtag(self, tag: str) -> None:
+        if tag == "see":
+            self.parts.append("</see>")
+            return
+        if tag in _PARAGRAPH_TAGS:
+            self.parts.append("\n\n")
+            return
+        if tag in ("ul", "ol"):
+            if self._lists:
+                self._lists.pop()
+            self.parts.append("\n")
+            return
+        if re.fullmatch(r"h[1-6]", tag):
+            self.parts.append("\n\n")
+            return
+        if tag in ("strong", "b"):
+            self.parts.append(_B_CLOSE)
+            return
+        if tag in ("em", "i"):
+            self.parts.append(_I_CLOSE)
+            return
+        if tag == "span":
+            if self._span_bold.pop() if self._span_bold else False:
+                self.parts.append(_B_CLOSE)
+
+    def handle_data(self, data: str) -> None:
+        if not data.strip():
+            # Drop inter-tag whitespace (e.g. the newline between <li> and its
+            # wrapping <p>) while a marker is hugging its first child, so the
+            # marker doesn't end up on a line of its own.
+            if self._suppress_para:
+                return
+            self.parts.append(data)
+            return
+        self._suppress_para = False
+        self.parts.append(data)
+
+    def get_markdown(self) -> str:
+        return "".join(self.parts)
+
+
+def html_to_markdown(html: str) -> str:
+    """Convert an HTML fragment (with ``<see>`` tags already inlined) to markdown.
+
+    Preserves paragraphs, ordered/unordered lists, headings and bold/italic
+    emphasis, and passes ``<see cref>``/``<see href>`` tags through untouched.
+    Trailing per-line whitespace and runs of blank lines are normalised.
+    """
+    parser = _HtmlToMarkdown()
+    parser.feed(html)
+    parser.close()
+    text = parser.get_markdown()
+
+    # Non-breaking spaces decoded from &nbsp; -> regular spaces.
+    text = text.replace("\xa0", " ")
+
+    # Resolve emphasis sentinels. CommonMark forbids whitespace directly inside
+    # the markers (``** foo **`` renders literally), and the source often wraps a
+    # trailing space inside <strong>, so relocate any inner whitespace outside
+    # the span and drop spans left empty.
+    text = re.sub(rf"{_B_OPEN}([ \t]+)", r"\1" + _B_OPEN, text)
+    text = re.sub(rf"([ \t]+){_B_CLOSE}", _B_CLOSE + r"\1", text)
+    text = re.sub(rf"{_I_OPEN}([ \t]+)", r"\1" + _I_OPEN, text)
+    text = re.sub(rf"([ \t]+){_I_CLOSE}", _I_CLOSE + r"\1", text)
+    text = text.replace(_B_OPEN + _B_CLOSE, "").replace(_I_OPEN + _I_CLOSE, "")
+    text = text.replace(_B_OPEN, "**").replace(_B_CLOSE, "**")
+    text = text.replace(_I_OPEN, "*").replace(_I_CLOSE, "*")
+
+    # Strip trailing whitespace on each line (the source riddles list items with
+    # a trailing space before the newline).
+    text = re.sub(r"[ \t]+\n", "\n", text)
+    # Collapse 3+ newlines to a single blank line.
+    text = re.sub(r"\n{3,}", "\n\n", text)
+    return text.strip()
 
 
 def convert_links_to_see_refs(html: str) -> str:
@@ -53,17 +240,10 @@ def convert_links_to_see_refs(html: str) -> str:
 
     result = re.sub(pattern, replace_link, html)
 
-    # Clean up HTML entities
-    result = result.replace("&nbsp;", " ")
-    result = result.replace("&amp;", "&")
-    result = result.replace("&lt;", "<")
-    result = result.replace("&gt;", ">")
-
-    # Clean up remaining HTML tags (like <p>, <div>, etc.)
-    # Keep <see cref="..."> and </see> tags
-    result = re.sub(r"<(?!/?see[\s>])[^>]+>", "", result)
-
-    return result.strip()
+    # Convert the remaining HTML structure (paragraphs, lists, headings, bold,
+    # …) to markdown, keeping the <see cref>/<see href> tags intact. This also
+    # decodes HTML entities and normalises whitespace.
+    return html_to_markdown(result)
 
 
 def href_to_see_ref(href: str) -> tuple[str, str]:


### PR DESCRIPTION
## What

`developing-solidworks` doc pages (e.g. `IFeatureManager/HoleWizard5.md`) rendered their **Remarks** and **Parameters** as run-on paragraphs — the bulleted hole/slot parameter lists, subheadings and bold labels were all flattened into unreadable text.

## Root cause

`shared/xmldoc_links.py :: convert_links_to_see_refs()` stripped **every** HTML tag except `<see>`, discarding `<ul>/<ol>/<li>/<p>/<h4>/<strong>` structure during **Phase 50 extraction** — before it was ever stored. Phase 120 (LLM markdown) and Phase 90 (XMLDoc) could not recover what was already gone.

## Fix

- Replace the blanket tag-strip with an `HTMLParser`-based **HTML→markdown** converter that preserves paragraphs, ordered/unordered lists (nesting + numbering), headings and bold/italic, while passing `<see cref>`/`<see href>` through untouched. Fixes both consumers at the source.
- **Phase 50:** keep `<h4>` subheadings inside remarks (were dropped as section sentinels) → render as `####`.
- **Phase 120:** indent multi-line parameter descriptions so sublists nest under their `- **Name**:` bullet.
- Relocate whitespace out of emphasis spans (`<strong>Remarks </strong>` → `**Remarks**`) so CommonMark recognises the emphasis.

Verified end-to-end by re-running Phase 50 → Phase 120 against the real crawled `HoleWizard5.html`: 6 `####` subheadings, correctly numbered 1–12 parameter lists, nested sublists, no invalid emphasis.

<details>
<summary>Note on the published bundle</summary>

This fixes the generation pipeline. The plugin bundle under `developing-solidworks/0.8.4/...` is a published artifact and needs a regeneration + republish (release step) to pick up the change.
</details>

## Tests

+11 regression tests (list/heading/bold conversion, emphasis-whitespace, h4-in-remarks, param indentation). Full suite: **323 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)