### PR TITLE
Render enum members as a table instead of per-member sections

### DIFF
--- a/120_export_llm_docs/README.md
+++ b/120_export_llm_docs/README.md
@@ -159,13 +159,10 @@ enum_member_count: 3
 
 ## Enumeration Members
 
-### swDocPART
-
-Part document type (*.sldprt)
-
-### swDocASSEMBLY
-
-Assembly document type (*.sldasm)
+| Member | Value |
+| --- | --- |
+| swDocPART | 1 = Part document type (*.sldprt) |
+| swDocASSEMBLY | 2 = Assembly document type (*.sldasm) |
 ```
 
 ### Example Files
@@ -302,8 +299,8 @@ grep -r "kind: method" output/types/
 # Find all enumerations
 grep -rl "kind: enum" output/enums/
 
-# Find a specific enum member (members are inline in the enum file)
-grep -rn "### swDocPART" output/enums/
+# Find a specific enum member (members are inline as table rows in the enum file)
+grep -rn "| swDocPART |" output/enums/
 ```
 
 ### Navigate by category

--- a/120_export_llm_docs/markdown_generator.py
+++ b/120_export_llm_docs/markdown_generator.py
@@ -235,13 +235,10 @@ class MarkdownGenerator:
             md.append("## Remarks\n")
             md.append(f"{self._clean_text(type_info.remarks)}\n")
 
-        # Enum Members
+        # Enum Members, as a Member | Value table
         if type_info.enum_members:
             md.append("## Enumeration Members\n")
-            for enum_member in type_info.enum_members:
-                md.append(f"### {enum_member.name}\n")
-                if enum_member.description:
-                    md.append(f"{self._clean_text(enum_member.description)}\n")
+            md.append(self._enum_members_table(type_info.enum_members, self._clean_text))
 
         # Properties
         if type_info.properties:
@@ -583,6 +580,23 @@ class MarkdownGenerator:
         filename = url.split('/')[-1].replace('.htm', '.md').replace('.html', '.md')
         return f"../examples/{filename}"
 
+    def _enum_members_table(self, enum_members: List[EnumMember], transform) -> str:
+        """Render enumeration members as a two-column ``Member | Value`` markdown table.
+
+        The source ``description`` is a merged ``value = meaning`` blob (or a bare
+        value), so it maps to a single ``Value`` cell. ``transform`` is applied to
+        each description (e.g. clean-up + cross-reference resolution). Cell content
+        is flattened: embedded pipes are escaped and newlines become ``<br>`` so
+        multi-line descriptions (lists, notes) don't break the table.
+        """
+        lines = ["| Member | Value |", "| --- | --- |"]
+        for enum_member in enum_members:
+            value = transform(enum_member.description) if enum_member.description else ""
+            value = value.strip().replace("|", "\\|")
+            value = re.sub(r"\n+", "<br>", value)
+            lines.append(f"| {enum_member.name} | {value} |")
+        return "\n".join(lines) + "\n"
+
     def generate_enum_documentation(self, type_info: TypeInfo, rel_prefix: str = DOCS_PREFIX_FLAT) -> str:
         """
         Generate a single self-contained markdown file for an enumeration, with all
@@ -623,12 +637,12 @@ class MarkdownGenerator:
             md.append("## Remarks\n")
             md.append(f"{self._simplify_cross_references(self._clean_text(type_info.remarks), rel_prefix)}\n")
 
-        # All enumeration members inline
+        # All enumeration members inline, as a Member | Value table
         md.append("## Enumeration Members\n")
-        for enum_member in type_info.enum_members:
-            md.append(f"### {enum_member.name}\n")
-            if enum_member.description:
-                md.append(f"{self._simplify_cross_references(self._clean_text(enum_member.description), rel_prefix)}\n")
+        md.append(self._enum_members_table(
+            type_info.enum_members,
+            lambda text: self._simplify_cross_references(self._clean_text(text), rel_prefix),
+        ))
 
         # Examples (enum-level, if any)
         if type_info.examples:

--- a/120_export_llm_docs/tests/test_grep_optimized_export.py
+++ b/120_export_llm_docs/tests/test_grep_optimized_export.py
@@ -211,12 +211,11 @@ def test_enum_documentation_generation():
     assert 'enum_member_count: 2' in enum_md
     assert 'assembly: SolidWorks.Interop.swconst' in enum_md
 
-    # Check that ALL members are inline in the single file
+    # Check that ALL members are inline in the single file, rendered as a table
     assert '## Enumeration Members' in enum_md
-    assert '### swValueA' in enum_md
-    assert 'Value A description' in enum_md
-    assert '### swValueB' in enum_md
-    assert 'Value B description' in enum_md
+    assert '| Member | Value |' in enum_md
+    assert '| swValueA | Value A description |' in enum_md
+    assert '| swValueB | Value B description |' in enum_md
 
     print("[PASS] Single-file enum documentation generation with members inline")
 
@@ -374,9 +373,10 @@ def test_enum_file_structure():
         assert 'is_enum: True' in content
         assert 'enum_member_count: 3' in content
         assert '## Enumeration Members' in content
-        assert '### swValue1' in content
-        assert '### swValue2' in content
-        assert '### swValue3' in content
+        assert '| Member | Value |' in content
+        assert '| swValue1 | Value 1 |' in content
+        assert '| swValue2 | Value 2 |' in content
+        assert '| swValue3 | Value 3 |' in content
 
     print("[PASS] Flat single-file enum structure generation")
 


### PR DESCRIPTION
Enum files (Phase 120) rendered each member as a `### {name}` section with its value below. For enums — most of which are just name→int maps — this is verbose and hard to scan. This switches to a two-column table:

```markdown
## Enumeration Members

| Member | Value |
| --- | --- |
| swBackView | 2 |
| swFrontView | 1 |
```

### Notes
- The source `description` is an already-merged `value = meaning` blob, and ~20% don't split cleanly (`13741 (see Remarks)`, `128 or 0x80: ...`, bare `Obsolete`), so it maps to a single **Value** cell verbatim rather than risking a fragile value/description split.
- Multi-line descriptions (bullet lists, `**NOTE:**` blocks — 24 enums) get newlines collapsed to `<br>` and pipes escaped so the table stays intact.
- Shared `_enum_members_table` helper used by both the live flat-enum path and the legacy type-doc path.

Regenerating the plugin bundle / release will produce the new tables; this PR only changes the generator, tests, and docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)