### PR TITLE
Drop redundant metadata duplicated in body (Assembly/Namespace, Return type)

### DIFF
--- a/120_export_llm_docs/README.md
+++ b/120_export_llm_docs/README.md
@@ -86,10 +86,6 @@ enum_member_count: 0
 
 # IModelDoc2
 
-**Assembly**: SolidWorks.Interop.sldworks
-**Namespace**: SolidWorks.Interop.sldworks
-**Category**: Application Interfaces
-
 ## Description
 
 Allows access to SOLIDWORKS documents: parts, assemblies, and drawings.

--- a/120_export_llm_docs/markdown_generator.py
+++ b/120_export_llm_docs/markdown_generator.py
@@ -456,9 +456,6 @@ class MarkdownGenerator:
         # Title
         md.append(f"# {type_info.name}\n")
 
-        # Metadata (one tight block; lines joined with markdown hard breaks)
-        md.append(self._metadata_block(type_info))
-
         # Description
         if type_info.description:
             md.append("## Description\n")
@@ -623,9 +620,8 @@ class MarkdownGenerator:
         md.append(f"enum_member_count: {len(type_info.enum_members)}")
         md.append("---\n")
 
-        # Title and metadata
+        # Title
         md.append(f"# {type_info.name}\n")
-        md.append(self._metadata_block(type_info))
 
         # Description
         if type_info.description:
@@ -665,21 +661,6 @@ class MarkdownGenerator:
         with open(output_path, 'w', encoding='utf-8') as f:
             f.write(self.generate_enum_documentation(type_info))
         return 1
-
-    def _metadata_block(self, type_info: TypeInfo) -> str:
-        """Render the Assembly/Namespace/Category metadata as one block.
-
-        Lines are joined with markdown hard breaks (two trailing spaces) so they
-        render on consecutive lines, and the block ends with a newline so the
-        join only adds a single blank line before the next section.
-        """
-        lines = [
-            f"**Assembly**: {type_info.assembly}",
-            f"**Namespace**: {type_info.namespace}",
-        ]
-        if type_info.functional_category:
-            lines.append(f"**Category**: {type_info.functional_category}")
-        return "  \n".join(lines) + "\n"
 
     def _render_see_also(self, see_also: List, rel_prefix: str = "") -> List[str]:
         """

--- a/120_export_llm_docs/markdown_generator.py
+++ b/120_export_llm_docs/markdown_generator.py
@@ -527,14 +527,11 @@ class MarkdownGenerator:
         if member.description:
             md.append(f"{self._simplify_cross_references(self._clean_text(member.description), rel_prefix)}\n")
 
-        # Signature (prefixed with the return type when known)
+        # Signature (prefixed with the return type when known, so the return
+        # type is carried here rather than duplicated on a separate line)
         if member.signature:
             full_signature = f"{member.return_type} {member.signature}".strip() if member.return_type else member.signature
             md.append(f"**Signature**: `{full_signature}`\n")
-
-        # Return type (called out separately for greppability)
-        if member.return_type:
-            md.append(f"**Return type**: `{member.return_type}`\n")
 
         # Parameters
         if member.parameters:

--- a/120_export_llm_docs/tests/test_see_also_and_indexes.py
+++ b/120_export_llm_docs/tests/test_see_also_and_indexes.py
@@ -54,9 +54,10 @@ def test_member_doc_includes_see_also_and_return_type(tmp_path):
     # P0: the stripped cross-link is restored
     assert "## See Also" in md
     assert "[[IComponent2::GetCorresponding Method]]" in md
-    # P3: return type is shown, not discarded
-    assert "**Return type**: `System.object`" in md
+    # P3: return type is shown (carried by the signature prefix), not discarded
+    # or duplicated on a separate line.
     assert "System.object GetCorrespondingEntity(" in md
+    assert "**Return type**:" not in md
 
 
 def test_by_member_name_index_clusters_siblings(tmp_path):


### PR DESCRIPTION
Removes two pieces of body content that duplicate metadata already carried elsewhere in the same file. (Re-opened from #20, which GitHub auto-closed when its base branch `feature/enum-members-table` was deleted on merge of #19; content is unchanged, rebased onto main.)

### 1. Assembly / Namespace / Category block
Type-overview and enum files rendered a `**Assembly**` / `**Namespace**` / `**Category**` block right under the H1 — duplicating the `assembly:` / `namespace:` / `category:` frontmatter fields. Member files never had it. Removed (and the now-unused `_metadata_block` helper); frontmatter is the single source.

### 2. Return type line
All 11,551 members carry both a return type and a signature, and the signature is rendered with the return type prefixed onto it:

```
**Signature**: `System.bool IgnoreValue( System.int RowID ) {get; set;}`
```

The separate `**Return type**: \`System.bool\`` line duplicated that in every file. Removed — the signature prefix is the single carrier. (No member has a return type but no signature, so nothing is lost.)

Tests + README example updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)