### PR TITLE
Tighten example-file headings; refresh README examples

### DIFF
--- a/120_export_llm_docs/README.md
+++ b/120_export_llm_docs/README.md
@@ -87,16 +87,13 @@ enum_member_count: 0
 # IModelDoc2
 
 ## Description
-
 Allows access to SOLIDWORKS documents: parts, assemblies, and drawings.
 
 ## Remarks
-
 There are three main SOLIDWORKS document types: parts, assemblies, and drawings.
 Each document type has its own object ([[IPartDoc]], [[IAssemblyDoc]], [[IDrawingDoc]])...
 
 ## Members
-
 - **Properties**: 24
 - **Methods**: 697
 ```
@@ -119,20 +116,17 @@ category: Application Interfaces
 
 Creates a sketch arc with the specified attributes.
 
-**Signature**: `CreateArc2( double CenterX, double CenterY, double CenterZ, ... )`
+**Signature**: `System.object CreateArc2( double CenterX, double CenterY, double CenterZ, ... )`
 
 ## Parameters
-
 - **CenterX**: X coordinate of arc center point
 - **CenterY**: Y coordinate of arc center point
 - **CenterZ**: Z coordinate of arc center point
 
 ## Returns
-
 Pointer to the [[ISketchArc]] object
 
 ## Remarks
-
 Use [[ISketchManager::CreateArc]] for more control over arc creation...
 ```
 
@@ -154,7 +148,6 @@ enum_member_count: 3
 # swDocumentTypes_e
 
 ## Enumeration Members
-
 | Member | Value |
 | --- | --- |
 | swDocPART | 1 = Part document type (*.sldprt) |
@@ -172,11 +165,9 @@ Each example gets its own markdown file in the appropriate category folder:
 **Source**: [Original URL]
 
 ## Description
-
 Example description extracted from content...
 
 ## Code
-
 ```csharp
 using SolidWorks.Interop.sldworks;
 

--- a/120_export_llm_docs/example_generator.py
+++ b/120_export_llm_docs/example_generator.py
@@ -54,12 +54,12 @@ class ExampleGenerator:
 
         # Description
         if description:
-            md.append("## Description\n")
+            md.append("## Description")
             md.append(f"{description}\n")
 
         # Code
         if code:
-            md.append("## Code\n")
+            md.append("## Code")
 
             # Detect language from code content
             language = self._detect_language(code, example.url)


### PR DESCRIPTION
Follow-up polish for the v3.10.0 formatting changes.

- **Example generator**: extends the heading tightening from #22 (which only touched `markdown_generator.py`) to `example_generator.py`, so `examples/*.md` render `## Description` / `## Code` directly above their content — the whole bundle is now consistent.
- **README**: refreshes the Phase 120 examples to match current output — tight headings throughout, and the member example signature now carries the return type (`System.object CreateArc2(...)`) since the dedicated `**Return type**` line was removed in the redundancy cleanup.

Verified: all 35 tests pass; regenerated bundle shows example files tight. Real member signatures already all include the return type (checked: 0 missing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)